### PR TITLE
Feature/#1

### DIFF
--- a/src/main/java/com/server/ggini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/server/ggini/domain/auth/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.server.ggini.domain.auth.controller;
+
+import com.server.ggini.domain.auth.dto.response.LoginResponse;
+import com.server.ggini.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "소셜 로그인으로 회원가입", description = "소셜 로그인 후 토큰과 회원 정보를 발급합니다.")
+    @PostMapping("/oauth/social-login")
+    public ResponseEntity<LoginResponse> socialLogin(
+            @RequestHeader("social_access_token") String accessToken,
+            @RequestParam("provider")
+            @Parameter(example = "kakao", description = "OAuth 제공자")
+            String provider
+    ) {
+        LoginResponse response = authService.socialLogin(accessToken, provider);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/server/ggini/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/server/ggini/domain/auth/domain/RefreshToken.java
@@ -1,0 +1,27 @@
+package com.server.ggini.domain.auth.domain;
+
+import com.server.ggini.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @Column(nullable = false, name = "refresh_token_id")
+    private Long memberId;
+    @Column(nullable = false)
+    private String token;
+
+    @Builder
+    public RefreshToken(Long memberId, String token) {
+        this.memberId = memberId;
+        this.token = token;
+    }
+}

--- a/src/main/java/com/server/ggini/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,7 @@
+package com.server.ggini.domain.auth.dto.request;
+
+public record RefreshTokenRequest(
+    String refreshToken
+) {
+
+}

--- a/src/main/java/com/server/ggini/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/response/LoginResponse.java
@@ -1,0 +1,15 @@
+package com.server.ggini.domain.auth.dto.response;
+
+import com.server.ggini.domain.member.domain.Member;
+
+public record LoginResponse(
+    Long memberId,
+    String nickname,
+    String accessToken,
+    String refreshToken
+) {
+
+    public static LoginResponse of(Member member, TokenPairResponse tokenPairResponse) {
+        return new LoginResponse(member.getId(), member.getNickname(), tokenPairResponse.accessToken(), tokenPairResponse.refreshToken());
+    }
+}

--- a/src/main/java/com/server/ggini/domain/auth/dto/response/TokenPairResponse.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/response/TokenPairResponse.java
@@ -1,0 +1,12 @@
+package com.server.ggini.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenPairResponse(
+        @Schema(description = "액세스 토큰", defaultValue = "accessToken") String accessToken,
+        @Schema(description = "리프레시 토큰", defaultValue = "refreshToken") String refreshToken) {
+
+    public static TokenPairResponse of(String accessToken, String refreshToken) {
+        return new TokenPairResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/server/ggini/domain/auth/dto/response/oauth/OauthUserInfoResponse.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/response/oauth/OauthUserInfoResponse.java
@@ -1,0 +1,24 @@
+package com.server.ggini.domain.auth.dto.response.oauth;
+
+import com.server.ggini.domain.auth.service.OAuthProvider;
+import com.server.ggini.domain.member.domain.OauthInfo;
+import lombok.Builder;
+
+@Builder
+public record OauthUserInfoResponse(
+    String oauthId,
+    String email,
+    String name,
+    OAuthProvider provider
+
+) {
+
+    public OauthInfo toEntity() {
+        return OauthInfo.builder()
+            .oauthId(this.oauthId())
+            .oauthEmail(this.email())
+            .name(this.name())
+            .oauthProvider(this.provider().name())
+            .build();
+    }
+}

--- a/src/main/java/com/server/ggini/domain/auth/dto/response/oauth/kakao/KakaoAuthResponse.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/response/oauth/kakao/KakaoAuthResponse.java
@@ -1,0 +1,13 @@
+package com.server.ggini.domain.auth.dto.response.oauth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoAuthResponse(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccountResponse kakaoAccount,
+        @JsonProperty("properties") PropertiesResponse properties) {
+    public record KakaoAccountResponse(String email) {}
+
+    public record PropertiesResponse(
+            String nickname, String profile_image, String thumbnail_image) {}
+}

--- a/src/main/java/com/server/ggini/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/server/ggini/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.server.ggini.domain.auth.repository;
+
+import com.server.ggini.domain.auth.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    boolean existsByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/server/ggini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/server/ggini/domain/auth/service/AuthService.java
@@ -1,0 +1,44 @@
+package com.server.ggini.domain.auth.service;
+
+import com.server.ggini.domain.auth.dto.response.LoginResponse;
+import com.server.ggini.domain.auth.dto.response.TokenPairResponse;
+import com.server.ggini.domain.auth.dto.response.oauth.OauthUserInfoResponse;
+import com.server.ggini.domain.auth.repository.RefreshTokenRepository;
+import com.server.ggini.domain.auth.service.kakao.KakaoClient;
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.domain.member.domain.OauthInfo;
+import com.server.ggini.domain.member.repository.MemberRepository;
+import com.server.ggini.domain.member.service.MemberService;
+import com.server.ggini.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoClient kakaoClient;
+    private final MemberRepository memberRepository;
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public LoginResponse socialLogin(String socialAccessToken, String provider) {
+        OauthUserInfoResponse oauthUserInfoResponse = getOauthUserInfo(socialAccessToken, OAuthProvider.from(provider));
+        OauthInfo oauthInfo = oauthUserInfoResponse.toEntity();
+
+        Member member = memberRepository.findByOauthInfo(oauthInfo)
+                .orElseGet(() -> memberService.createMember(oauthInfo));
+
+        TokenPairResponse tokenPairResponse = jwtTokenProvider.generateTokenPair(member.getId(), member.getRole());
+        return LoginResponse.of(member, tokenPairResponse);
+    }
+
+    private OauthUserInfoResponse getOauthUserInfo(String socialAccessToken, OAuthProvider provider) {
+        return switch (provider) {
+            case APPLE -> null; //TODO: Apple OAuth
+            case KAKAO -> kakaoClient.getOauthUserInfo(socialAccessToken);
+        };
+    }
+}

--- a/src/main/java/com/server/ggini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/server/ggini/domain/auth/service/AuthService.java
@@ -3,11 +3,9 @@ package com.server.ggini.domain.auth.service;
 import com.server.ggini.domain.auth.dto.response.LoginResponse;
 import com.server.ggini.domain.auth.dto.response.TokenPairResponse;
 import com.server.ggini.domain.auth.dto.response.oauth.OauthUserInfoResponse;
-import com.server.ggini.domain.auth.repository.RefreshTokenRepository;
 import com.server.ggini.domain.auth.service.kakao.KakaoClient;
 import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.domain.member.domain.OauthInfo;
-import com.server.ggini.domain.member.repository.MemberRepository;
 import com.server.ggini.domain.member.service.MemberService;
 import com.server.ggini.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final KakaoClient kakaoClient;
-    private final MemberRepository memberRepository;
     private final MemberService memberService;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -28,8 +25,7 @@ public class AuthService {
         OauthUserInfoResponse oauthUserInfoResponse = getOauthUserInfo(socialAccessToken, OAuthProvider.from(provider));
         OauthInfo oauthInfo = oauthUserInfoResponse.toEntity();
 
-        Member member = memberRepository.findByOauthInfo(oauthInfo)
-                .orElseGet(() -> memberService.createMember(oauthInfo));
+        Member member = memberService.getMemberByOAuthInfo(oauthInfo);
 
         TokenPairResponse tokenPairResponse = jwtTokenProvider.generateTokenPair(member.getId(), member.getRole());
         return LoginResponse.of(member, tokenPairResponse);

--- a/src/main/java/com/server/ggini/domain/auth/service/OAuthProvider.java
+++ b/src/main/java/com/server/ggini/domain/auth/service/OAuthProvider.java
@@ -1,0 +1,23 @@
+package com.server.ggini.domain.auth.service;
+
+import com.server.ggini.global.error.exception.ErrorCode;
+import com.server.ggini.global.error.exception.InvalidValueException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthProvider {
+    KAKAO("KAKAO"),
+    APPLE("APPLE"),
+    ;
+    private final String value;
+
+    public static OAuthProvider from(String provider) {
+        return switch (provider.toUpperCase()) {
+            case "APPLE" -> APPLE;
+            case "KAKAO" -> KAKAO;
+            default -> throw new InvalidValueException(ErrorCode.INVALID_PROVIDER_TYPE);
+        };
+    }
+}

--- a/src/main/java/com/server/ggini/domain/auth/service/apple/AppleClient.java
+++ b/src/main/java/com/server/ggini/domain/auth/service/apple/AppleClient.java
@@ -1,0 +1,4 @@
+package com.server.ggini.domain.auth.service.apple;
+
+public class AppleClient {
+}

--- a/src/main/java/com/server/ggini/domain/auth/service/kakao/KakaoClient.java
+++ b/src/main/java/com/server/ggini/domain/auth/service/kakao/KakaoClient.java
@@ -1,0 +1,43 @@
+package com.server.ggini.domain.auth.service.kakao;
+
+import com.server.ggini.domain.auth.dto.response.oauth.OauthUserInfoResponse;
+import com.server.ggini.domain.auth.dto.response.oauth.kakao.KakaoAuthResponse;
+import com.server.ggini.domain.auth.service.OAuthProvider;
+import com.server.ggini.global.error.exception.AccessDeniedException;
+import com.server.ggini.global.error.exception.ErrorCode;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoClient {
+
+    private final RestClient restClient;
+    public static final String KAKAO_USER_ME_URL = "https://kapi.kakao.com/v2/user/me";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    public OauthUserInfoResponse getOauthUserInfo(String token) {
+        KakaoAuthResponse kakaoAuthResponse =
+                restClient
+                        .get()
+                        .uri(KAKAO_USER_ME_URL)
+                        .header("Authorization", TOKEN_PREFIX + token)
+                        .exchange(
+                                (request, response) -> {
+                                    if (!response.getStatusCode().is2xxSuccessful()) {
+                                        throw new AccessDeniedException(ErrorCode.KAKAO_TOKEN_CLIENT_FAILED);
+                                    }
+                                    return Objects.requireNonNull(
+                                            response.bodyTo(KakaoAuthResponse.class));
+                                });
+
+        return new OauthUserInfoResponse(
+                kakaoAuthResponse.id().toString(),
+                kakaoAuthResponse.kakaoAccount().email(),
+                kakaoAuthResponse.properties().nickname(),
+                OAuthProvider.KAKAO
+        );
+    }
+}

--- a/src/main/java/com/server/ggini/domain/member/domain/Member.java
+++ b/src/main/java/com/server/ggini/domain/member/domain/Member.java
@@ -1,0 +1,55 @@
+package com.server.ggini.domain.member.domain;
+
+import com.server.ggini.domain.member.domain.nickName.Adjective;
+import com.server.ggini.domain.member.domain.nickName.Animal;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    @Embedded
+    private OauthInfo oauthInfo;
+
+    @Builder
+    public Member(String nickname, MemberRole role, OauthInfo oauthInfo) {
+        this.nickname = nickname;
+        this.role = role;
+        this.oauthInfo = oauthInfo;
+    }
+
+    public static String createNickname() {
+
+        return Adjective.getRandomName() + Animal.getRandomName();
+    }
+
+    public static Member createDefaultMember(String nickname, OauthInfo oauthInfo) {
+        return Member.builder()
+                .nickname(nickname)
+                .role(MemberRole.USER)
+                .oauthInfo(oauthInfo)
+                .build();
+    }
+}

--- a/src/main/java/com/server/ggini/domain/member/domain/MemberRole.java
+++ b/src/main/java/com/server/ggini/domain/member/domain/MemberRole.java
@@ -1,0 +1,21 @@
+package com.server.ggini.domain.member.domain;
+
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRole {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String value;
+
+    public static MemberRole findByKey(String value) {
+        return Arrays.stream(MemberRole.values())
+                .filter(role -> role.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No role with key: " + value));
+    }
+}

--- a/src/main/java/com/server/ggini/domain/member/domain/OauthInfo.java
+++ b/src/main/java/com/server/ggini/domain/member/domain/OauthInfo.java
@@ -1,0 +1,27 @@
+package com.server.ggini.domain.member.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OauthInfo {
+
+    public String oauthId;
+    private String oauthProvider;
+    private String oauthEmail;
+    private String name;
+
+    @Builder
+    public OauthInfo(String oauthId, String oauthProvider, String oauthEmail, String name) {
+        this.oauthId = oauthId;
+        this.oauthProvider = oauthProvider;
+        this.oauthEmail = oauthEmail;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/server/ggini/domain/member/domain/nickName/Adjective.java
+++ b/src/main/java/com/server/ggini/domain/member/domain/nickName/Adjective.java
@@ -1,0 +1,19 @@
+package com.server.ggini.domain.member.domain.nickName;
+
+import java.util.List;
+import java.util.Random;
+
+public enum Adjective {
+	깐깐한, 열받은, 배부른, 배고픈, 친절한, 행복한, 즐거운, 졸린, 피곤한, 게으른, 슬픈,
+	무서운, 착한, 느긋한, 용감한, 성실한, 명랑한, 조용한, 화난, 진지한, 우울한,
+	신나는, 목마른, 차가운, 뜨거운, 시원한, 따뜻한, 깨끗한, 불안한, 활발한, 우직한,
+	단순한, 복잡한, 유쾌한, 놀라운, 당당한, 솔직한, 겸손한, 부끄러운, 당황한,
+	차분한, 민첩한, 투명한, 고요한, 온화한;
+
+	private static final List<Adjective> VALUES = List.of(values());
+	private static final Random RANDOM = new Random();
+
+	public static String getRandomName() {
+		return VALUES.get(RANDOM.nextInt(VALUES.size())).name();
+	}
+}

--- a/src/main/java/com/server/ggini/domain/member/domain/nickName/Animal.java
+++ b/src/main/java/com/server/ggini/domain/member/domain/nickName/Animal.java
@@ -1,0 +1,16 @@
+package com.server.ggini.domain.member.domain.nickName;
+
+import java.util.List;
+import java.util.Random;
+
+public enum Animal {
+	돼지, 고양이, 강아지, 반달곰, 다람쥐, 토끼, 상어, 금붕어, 사자, 악어, 여우, 고래,
+	표범, 수달, 사슴, 기린, 박쥐, 나비, 제비, 개미, 하마, 물개;
+
+	private static final List<Animal> VALUES = List.of(values());
+	private static final Random RANDOM = new Random();
+
+	public static String getRandomName() {
+		return VALUES.get(RANDOM.nextInt(VALUES.size())).name();
+	}
+}

--- a/src/main/java/com/server/ggini/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/ggini/domain/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.server.ggini.domain.member.repository;
+
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.domain.member.domain.OauthInfo;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
+    Optional<Member> findByNickname(String nickname);
+
+}

--- a/src/main/java/com/server/ggini/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/ggini/domain/member/service/MemberService.java
@@ -14,14 +14,18 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Member createMember(OauthInfo oauthInfo) {
+    public Member getMemberByOAuthInfo(OauthInfo oauthInfo) {
+        return memberRepository.findByOauthInfo(oauthInfo)
+                .orElseGet(() -> createMember(oauthInfo));
+    }
+
+    private Member createMember(OauthInfo oauthInfo) {
         String nickname;
         do {
             nickname = Member.createNickname();
         } while (memberRepository.findByNickname(nickname).isPresent());
 
         Member member = Member.createDefaultMember(nickname, oauthInfo);
-
         return memberRepository.save(member);
     }
 

--- a/src/main/java/com/server/ggini/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/ggini/domain/member/service/MemberService.java
@@ -1,0 +1,28 @@
+package com.server.ggini.domain.member.service;
+
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.domain.member.domain.OauthInfo;
+import com.server.ggini.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member createMember(OauthInfo oauthInfo) {
+        String nickname;
+        do {
+            nickname = Member.createNickname();
+        } while (memberRepository.findByNickname(nickname).isPresent());
+
+        Member member = Member.createDefaultMember(nickname, oauthInfo);
+
+        return memberRepository.save(member);
+    }
+
+}

--- a/src/main/java/com/server/ggini/global/common/BaseEntity.java
+++ b/src/main/java/com/server/ggini/global/common/BaseEntity.java
@@ -1,0 +1,34 @@
+package com.server.ggini.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@NoArgsConstructor
+@MappedSuperclass
+@SuperBuilder
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(name = "update_at")
+    private LocalDateTime updatedDate;
+
+    @Column(name = "deleted")
+    @Builder.Default
+    private boolean deleted = false;
+
+}

--- a/src/main/java/com/server/ggini/global/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/server/ggini/global/config/properties/PropertiesConfig.java
@@ -1,0 +1,13 @@
+package com.server.ggini.global.config.properties;
+
+import com.server.ggini.global.properties.jwt.JwtProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties({
+    JwtProperties.class
+})
+@Configuration
+public class PropertiesConfig {
+
+}

--- a/src/main/java/com/server/ggini/global/config/restClient/RestClientConfig.java
+++ b/src/main/java/com/server/ggini/global/config/restClient/RestClientConfig.java
@@ -1,0 +1,24 @@
+package com.server.ggini.global.config.restClient;
+
+import java.time.Duration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(10));
+        requestFactory.setReadTimeout(Duration.ofSeconds(5));
+
+        return RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
+    }
+}

--- a/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
@@ -1,0 +1,81 @@
+package com.server.ggini.global.config.security;
+
+import com.server.ggini.global.security.JwtTokenProvider;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private String[] allowUrls = {"/", "/favicon.ico",
+        "/api/v1/auth/**", "/swagger-ui/**", "/v3/**"};
+
+    @Value("${cors-allowed-origins}")
+    private List<String> corsAllowedOrigins;
+
+    @Bean
+    public WebSecurityCustomizer configure() {
+        // filter 안타게 무시
+        return (web) -> web.ignoring().requestMatchers(allowUrls);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .cors(customizer -> customizer.configurationSource(corsConfigurationSource()))
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(request -> request
+                .requestMatchers(allowUrls).permitAll()
+                .anyRequest().authenticated());
+
+        http
+            .exceptionHandling(exception ->
+                exception.authenticationEntryPoint((request, response, authException) ->
+                    response.setStatus(HttpStatus.UNAUTHORIZED.value()))); // 인증,인가가 되지 않은 요청 시 발생시
+
+//        http
+//            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+//            .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(corsAllowedOrigins);
+        configuration.addAllowedMethod("*");
+        configuration.setAllowedHeaders(List.of("*")); // 허용할 헤더
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 적용
+        return source;
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/server/ggini/global/error/ErrorResponse.java
+++ b/src/main/java/com/server/ggini/global/error/ErrorResponse.java
@@ -1,0 +1,25 @@
+package com.server.ggini.global.error;
+
+import com.server.ggini.global.error.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+    private String message;
+    private HttpStatus status;
+
+    private ErrorResponse(final ErrorCode code) {
+        this.message = code.getMessage();
+        this.status = code.getStatus();
+    }
+
+    public static ErrorResponse from(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+}

--- a/src/main/java/com/server/ggini/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/server/ggini/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,59 @@
+package com.server.ggini.global.error;
+
+import com.server.ggini.global.error.exception.BusinessException;
+import com.server.ggini.global.error.exception.ErrorCode;
+import com.server.ggini.global.error.exception.NotFoundException;
+import io.jsonwebtoken.JwtException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException exception) {
+        log.error("handleBusinessException", exception);
+        final ErrorCode errorCode = exception.getErrorCode();
+        final ErrorResponse response = ErrorResponse.from(errorCode);
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<String> handleNoHandlerFoundException(NoHandlerFoundException ex) {
+        return new ResponseEntity<>("존재하지 않은 요청 엔드포인트입니다", HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(final NotFoundException exception) {
+        log.error("handleEntityNotFoundException", exception);
+        final ErrorCode errorCode = exception.getErrorCode();
+        final ErrorResponse response = ErrorResponse.from(exception.getErrorCode());
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(final Exception exception) {
+        log.error(exception.getMessage(), exception);
+        final ErrorResponse response = ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR);
+
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
+    @ExceptionHandler(JwtException.class)
+    protected ResponseEntity<ErrorResponse> handleJwtException(final JwtException exception) {
+        log.error("handleEntityNotFoundException", exception);
+        final ErrorCode errorCode = ErrorCode.RT_NOT_FOUND;
+        final ErrorResponse response = ErrorResponse.from(errorCode);
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+}

--- a/src/main/java/com/server/ggini/global/error/exception/AccessDeniedException.java
+++ b/src/main/java/com/server/ggini/global/error/exception/AccessDeniedException.java
@@ -1,0 +1,12 @@
+package com.server.ggini.global.error.exception;
+
+public class AccessDeniedException extends BusinessException{
+
+    public AccessDeniedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AccessDeniedException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/server/ggini/global/error/exception/BusinessException.java
+++ b/src/main/java/com/server/ggini/global/error/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package com.server.ggini.global.error.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/server/ggini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/server/ggini/global/error/exception/ErrorCode.java
@@ -1,0 +1,47 @@
+package com.server.ggini.global.error.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Test"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류, 관리자에게 문의하세요"),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 엔티티를 찾을 수 없습니다."),
+
+
+    //Auth
+    AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "시큐리티 인증 정보를 찾을 수 없습니다."),
+    UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "알 수 없는 에러"),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 access Token입니다"),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 refresh Token입니다. 재로그인하세요"),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 길이 및 형식이 다른 Token입니다"),
+    WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "서명이 잘못된 토큰입니다."),
+    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "토큰이 없습니다"),
+    TOKEN_SUBJECT_FORMAT_ERROR(HttpStatus.UNAUTHORIZED, "Subject 값에 Long 타입이 아닌 다른 타입이 들어있습니다."),
+    AT_EXPIRED_AND_RT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AT는 만료되었고 RT는 비어있습니다."),
+    RT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "RT가 비어있습니다"),
+
+    //OAuth
+    KAKAO_TOKEN_CLIENT_FAILED(HttpStatus.UNAUTHORIZED, "카카오 AT 인증이 실패했습니다."),
+    AUTH_GET_USER_INFO_FAILED(HttpStatus.UNAUTHORIZED, "SocialAccessToken을 통해 사용자 정보를 가져오는 데에 실패했습니다."),
+    INVALID_PROVIDER_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 provider를 입력하셨습니다."),
+    PASSWORD_NOT_MATCHES(HttpStatus.BAD_REQUEST, "비밀번호를 잘못 입력하셨습니다."),
+
+    //User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 직업을 찾을 수 없습니다"),
+    ONBOARD_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 온보딩 상태를 찾을 수 없습니다. (잘못된 온보딩 상태를 입력하셨습니다)"),
+
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/server/ggini/global/error/exception/InvalidValueException.java
+++ b/src/main/java/com/server/ggini/global/error/exception/InvalidValueException.java
@@ -1,0 +1,13 @@
+package com.server.ggini.global.error.exception;
+
+public class InvalidValueException extends BusinessException{
+
+    public InvalidValueException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InvalidValueException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+}

--- a/src/main/java/com/server/ggini/global/error/exception/NotFoundException.java
+++ b/src/main/java/com/server/ggini/global/error/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.server.ggini.global.error.exception;
+
+public class NotFoundException extends BusinessException{
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public NotFoundException(String message) {
+        super(message, ErrorCode.ENTITY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/server/ggini/global/properties/jwt/JwtProperties.java
+++ b/src/main/java/com/server/ggini/global/properties/jwt/JwtProperties.java
@@ -1,0 +1,21 @@
+package com.server.ggini.global.properties.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+    String accessTokenSecret,
+    String refreshTokenSecret,
+    Long accessTokenExpirationTime,
+    Long refreshTokenExpirationTime,
+    String issuer
+) {
+
+    public Long accessTokenExpirationMilliTime() {
+        return accessTokenExpirationTime * 1000;
+    }
+
+    public Long refreshTokenExpirationMilliTime() {
+        return refreshTokenExpirationTime * 1000;
+    }
+}

--- a/src/main/java/com/server/ggini/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/server/ggini/global/security/JwtTokenProvider.java
@@ -1,0 +1,43 @@
+package com.server.ggini.global.security;
+
+import com.server.ggini.domain.auth.domain.RefreshToken;
+import com.server.ggini.domain.auth.dto.response.TokenPairResponse;
+import com.server.ggini.domain.auth.repository.RefreshTokenRepository;
+import com.server.ggini.domain.member.domain.MemberRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+
+    public TokenPairResponse generateTokenPair(Long memberId, MemberRole memberRole) {
+        String accessToken = createAccessToken(memberId, memberRole);
+        String refreshToken = createRefreshToken(memberId, memberRole);
+        return TokenPairResponse.of(accessToken, refreshToken);
+    }
+
+    private String createAccessToken(Long memberId, MemberRole memberRole) {
+        return jwtUtil.generateAccessToken(memberId, memberRole);
+    }
+
+    private String createRefreshToken(Long memberId, MemberRole memberRole) {
+        String token = jwtUtil.generateRefreshToken(memberId, memberRole);
+        saveRefreshToken(memberId, token);
+        return token;
+    }
+
+    private void saveRefreshToken(Long memberId, String refreshToken) {
+        if(refreshTokenRepository.existsByMemberId(memberId)) {
+            refreshTokenRepository.deleteByMemberId(memberId);
+        }
+        refreshTokenRepository.save(RefreshToken.builder()
+                .memberId(memberId)
+                .token(refreshToken)
+                .build());
+    }
+}

--- a/src/main/java/com/server/ggini/global/security/JwtUtil.java
+++ b/src/main/java/com/server/ggini/global/security/JwtUtil.java
@@ -1,0 +1,57 @@
+package com.server.ggini.global.security;
+
+import com.server.ggini.domain.member.domain.MemberRole;
+import com.server.ggini.global.properties.jwt.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    public static final String TOKEN_ROLE_NAME = "role";
+    private final JwtProperties jwtProperties;
+
+    public String generateAccessToken(Long memberId, MemberRole role) {
+        Date issuedAt = new Date();
+        Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        return Jwts.builder()
+            .setIssuer(jwtProperties.issuer())
+            .setSubject(memberId.toString())
+            .claim(TOKEN_ROLE_NAME, role.getValue())
+            .setIssuedAt(issuedAt)
+            .setExpiration(expiredAt)
+            .signWith(getAccessTokenKey())
+            .compact();
+    }
+
+    public String generateRefreshToken(Long memberId, MemberRole role) {
+        Date issuedAt = new Date();
+        Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+
+        return Jwts.builder()
+            .setIssuer(jwtProperties.issuer())
+            .setSubject(memberId.toString())
+            .claim(TOKEN_ROLE_NAME, role.getValue())
+            .setIssuedAt(issuedAt)
+            .setExpiration(expiredAt)
+            .signWith(getRefreshTokenKey())
+            .compact();
+    }
+
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
+    }
+
+    private Key getRefreshTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.refreshTokenSecret().getBytes());
+    }
+}

--- a/src/main/resources/application-datasource.yml
+++ b/src/main/resources/application-datasource.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    activate:
+      on-profile: "datasource"
+  datasource:
+    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&tinyInt1isBit=false
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    password: ${MYSQL_PASSWORD}
+    username: ${MYSQL_USER}
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        default_batch_fetch_size: 1000
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+    hibernate:
+      ddl-auto: update
+
+cors-allowed-origins:
+  http://localhost:8080,
+  http://localhost:3000,
+
+

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,0 +1,13 @@
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET:}
+  refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET:}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:36000000} #10000시간
+  refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:604800} #7일
+  issuer: ${JWT_ISSUER:}
+
+
+kakao:
+  login:
+    client_id: ${KAKAO_LOGIN_CLIENT_ID}
+    client_secret: ${KAKAO_LOGIN_CLIENT_SECRET}
+    redirect_uri: ${KAKAO_LOGIN_REDIRECT_URI}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1 

## 📌 작업 내용 및 특이사항
### 1. 카카오 사용자 정보 인가 api 연결

- RestClient를 통해서 카카오 인가 서버와 연결을 하였습니다.
- 로그인에서 에러발생 시 회원가입 자체를 탈주할 것을 우려하여

   - ConnectTimeout은 3번의 패킷 유실까지 커버하여 10초
   - ReadTimeout은 넉넉히 5초로 설정하였습니다.
   - [참고] https://alden-kang.tistory.com/20 ( 타임아웃 설정에 관한 글 
   - [참고2] https://devtalk.kakao.com/t/topic/135741 (카카오 로그인 api는 보통 100ms내로 응답이 오는 것 같네요)
 
### 2. JwtTokenProvider로 accessToken과 refreshToken을 생성합니다.

### 3. 소셜 로그인 시 소셜 회원 정보 바탕으로 회원 가입도 바로 진행합니다
 -  사용자 닉네임은 형용사 개수 45 x 동물 명사 개수 22 = 990개의 닉네임 중 랜덤으로 설정됩니다.
   - 추후 닉네임 생성이 동시에 되어 닉네임이 중복되는 이슈에 대해선 추후 처리하겠습니다.
  
## 📝 참고사항
- 카카오 accessToken 발급은 아래 페이지하여 swagger로 테스트 해볼 수 있습니다.
 - https://developers.kakao.com/tool/rest-api/open/post/v1-user-logout
