### PR TITLE
Feature/#8 어드민 이메일, 패스워드 방식의 로그인 인증 추가 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,9 @@ name: Gradle Package
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - "main"
+      - "develop"
 
 jobs:
   build:
@@ -30,7 +32,7 @@ jobs:
           distribution: 'temurin'
 
 
-      - name: build
+      - name: build and test
         run: |
           chmod +x gradlew
           ./gradlew build 

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 
     // validator
     implementation 'commons-validator:commons-validator:1.7'
+
+    //db-h2
+    implementation 'com.h2database:h2'
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,11 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // validator
+    implementation 'commons-validator:commons-validator:1.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/server/ggini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/server/ggini/domain/auth/controller/AuthController.java
@@ -1,12 +1,20 @@
 package com.server.ggini.domain.auth.controller;
 
+import com.server.ggini.domain.auth.dto.request.AdminLoginRequest;
 import com.server.ggini.domain.auth.dto.response.LoginResponse;
 import com.server.ggini.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,5 +37,25 @@ public class AuthController {
     ) {
         LoginResponse response = authService.socialLogin(accessToken, provider);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "어드민 로그인", description = "아아디 패스워드 로그인 후 토큰 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    headers = {
+                            @Header(name = "Authorization", description = "Access Token", schema = @Schema(type = "string")),
+                            @Header(name = "RefreshToken", description = "Refresh Token", schema = @Schema(type = "string"))
+                    }
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @PostMapping("/admin/login")
+    public void adminLogin(
+            @RequestBody AdminLoginRequest request
+    ) {
+        // 실제 처리는 Security 필터에서 이루어지며, 이 메서드는 Swagger 명세용입니다.
     }
 }

--- a/src/main/java/com/server/ggini/domain/auth/dto/request/AdminLoginRequest.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/request/AdminLoginRequest.java
@@ -1,0 +1,7 @@
+package com.server.ggini.domain.auth.dto.request;
+
+public record AdminLoginRequest(
+        String email,
+        String password
+) {
+}

--- a/src/main/java/com/server/ggini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/server/ggini/domain/auth/service/AuthService.java
@@ -7,7 +7,7 @@ import com.server.ggini.domain.auth.service.kakao.KakaoClient;
 import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.domain.member.domain.OauthInfo;
 import com.server.ggini.domain.member.service.MemberService;
-import com.server.ggini.global.security.JwtTokenProvider;
+import com.server.ggini.global.security.provider.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +27,7 @@ public class AuthService {
 
         Member member = memberService.getMemberByOAuthInfo(oauthInfo);
 
-        TokenPairResponse tokenPairResponse = jwtTokenProvider.generateTokenPair(member.getId(), member.getRole());
+        TokenPairResponse tokenPairResponse = jwtTokenProvider.generateTokenPair(member);
         return LoginResponse.of(member, tokenPairResponse);
     }
 

--- a/src/main/java/com/server/ggini/domain/auth/service/kakao/KakaoClient.java
+++ b/src/main/java/com/server/ggini/domain/auth/service/kakao/KakaoClient.java
@@ -7,9 +7,13 @@ import com.server.ggini.global.error.exception.AccessDeniedException;
 import com.server.ggini.global.error.exception.ErrorCode;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KakaoClient {
@@ -26,7 +30,12 @@ public class KakaoClient {
                         .header("Authorization", TOKEN_PREFIX + token)
                         .exchange(
                                 (request, response) -> {
+                                    HttpStatusCode statusCode = response.getStatusCode();
+                                    log.info("Received response with status: {}", statusCode);
+
                                     if (!response.getStatusCode().is2xxSuccessful()) {
+                                        log.error("Kakao API error. Status: {}, Response: {}",
+                                                statusCode, response.bodyTo(String.class));
                                         throw new AccessDeniedException(ErrorCode.KAKAO_TOKEN_CLIENT_FAILED);
                                     }
                                     return Objects.requireNonNull(

--- a/src/main/java/com/server/ggini/domain/member/domain/Member.java
+++ b/src/main/java/com/server/ggini/domain/member/domain/Member.java
@@ -27,6 +27,9 @@ public class Member {
 
     private String nickname;
 
+    private String email;
+    private String password;
+
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 

--- a/src/main/java/com/server/ggini/domain/member/domain/Member.java
+++ b/src/main/java/com/server/ggini/domain/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.server.ggini.domain.member.domain;
 
 import com.server.ggini.domain.member.domain.nickName.Adjective;
 import com.server.ggini.domain.member.domain.nickName.Animal;
+import com.server.ggini.global.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,8 +38,10 @@ public class Member {
     private OauthInfo oauthInfo;
 
     @Builder
-    public Member(String nickname, MemberRole role, OauthInfo oauthInfo) {
+    public Member(String nickname, String email, String password, MemberRole role, OauthInfo oauthInfo) {
         this.nickname = nickname;
+        this.email = email;
+        this.password = password;
         this.role = role;
         this.oauthInfo = oauthInfo;
     }

--- a/src/main/java/com/server/ggini/domain/member/domain/Member.java
+++ b/src/main/java/com/server/ggini/domain/member/domain/Member.java
@@ -46,6 +46,10 @@ public class Member extends BaseEntity {
         this.oauthInfo = oauthInfo;
     }
 
+    public boolean isMatchingPassword(String password) {
+        return this.password.equals(password);
+    }
+
     public static String createNickname() {
 
         return Adjective.getRandomName() + Animal.getRandomName();

--- a/src/main/java/com/server/ggini/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/ggini/domain/member/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.server.ggini.domain.member.repository;
 
 import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.domain.member.domain.OauthInfo;
+import com.server.ggini.global.error.exception.ErrorCode;
+import com.server.ggini.global.error.exception.NotFoundException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNickname(String nickname);
     Optional<Member> findByEmail(String email);
 
+
+    default Member findByEmailOrThrow(String email) {
+        return findByEmail(email).orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/server/ggini/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/ggini/domain/member/repository/MemberRepository.java
@@ -8,5 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
     Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByEmail(String email);
 
 }

--- a/src/main/java/com/server/ggini/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/ggini/domain/member/service/MemberService.java
@@ -31,8 +31,6 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public Member getMemberByEmail(String email) {
-        return memberRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("해당 이메일로 가입된 회원이 없습니다."));
+        return memberRepository.findByEmailOrThrow(email);
     }
-
 }

--- a/src/main/java/com/server/ggini/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/ggini/domain/member/service/MemberService.java
@@ -29,4 +29,10 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
+    @Transactional(readOnly = true)
+    public Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일로 가입된 회원이 없습니다."));
+    }
+
 }

--- a/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
 
     private String[] allowUrls = {"/", "/favicon.ico",
-        "/api/v1/auth/**", "/swagger-ui/**", "/v3/**"};
+        "/api/v1/auth/oauth/**", "/swagger-ui/**", "/v3/**"};
 
     @Value("${cors-allowed-origins}")
     private List<String> corsAllowedOrigins;

--- a/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
@@ -1,12 +1,19 @@
 package com.server.ggini.global.config.security;
 
-import com.server.ggini.global.security.JwtTokenProvider;
+import com.server.ggini.domain.member.service.MemberService;
+import com.server.ggini.global.security.handler.EmailPasswordSuccessHandler;
+import com.server.ggini.global.security.provider.JwtTokenProvider;
+import com.server.ggini.global.security.filter.EmailPasswordAuthenticationFilter;
+import com.server.ggini.global.security.provider.EmailPasswordAuthenticationProvider;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -24,7 +31,10 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final MemberService memberService;
+    private final EmailPasswordSuccessHandler emailPasswordSuccessHandler;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationConfiguration authenticationConfiguration;
 
     private String[] allowUrls = {"/", "/favicon.ico",
         "/api/v1/auth/**", "/swagger-ui/**", "/v3/**"};
@@ -37,6 +47,8 @@ public class SecurityConfig {
         // filter 안타게 무시
         return (web) -> web.ignoring().requestMatchers(allowUrls);
     }
+
+
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -54,11 +66,33 @@ public class SecurityConfig {
                 exception.authenticationEntryPoint((request, response, authException) ->
                     response.setStatus(HttpStatus.UNAUTHORIZED.value()))); // 인증,인가가 되지 않은 요청 시 발생시
 
-//        http
+        http
+            .addFilterAt(emailPasswordAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 //            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
 //            .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public EmailPasswordAuthenticationFilter emailPasswordAuthenticationFilter() throws Exception {
+        EmailPasswordAuthenticationFilter emailPasswordAuthenticationFilter = new EmailPasswordAuthenticationFilter(authenticationManager(authenticationConfiguration));
+        emailPasswordAuthenticationFilter.setFilterProcessesUrl("/api/v1/auth/admin/login");
+        emailPasswordAuthenticationFilter.setAuthenticationSuccessHandler(emailPasswordSuccessHandler);
+        emailPasswordAuthenticationFilter.afterPropertiesSet();
+        return emailPasswordAuthenticationFilter;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        ProviderManager providerManager = (ProviderManager) authenticationConfiguration.getAuthenticationManager();
+        providerManager.getProviders().add(emailPasswordAuthenticationProvider());
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public EmailPasswordAuthenticationProvider emailPasswordAuthenticationProvider() {
+        return new EmailPasswordAuthenticationProvider(memberService, bCryptPasswordEncoder());
     }
 
     @Bean

--- a/src/main/java/com/server/ggini/global/error/ErrorResponse.java
+++ b/src/main/java/com/server/ggini/global/error/ErrorResponse.java
@@ -1,6 +1,7 @@
 package com.server.ggini.global.error;
 
 import com.server.ggini.global.error.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,9 @@ import org.springframework.http.HttpStatus;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
 
+    @Schema(description = "에러 메시지", example = "서버 오류, 관리자에게 문의하세요")
     private String message;
+    @Schema(example = "500")
     private HttpStatus status;
 
     private ErrorResponse(final ErrorCode code) {

--- a/src/main/java/com/server/ggini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/server/ggini/global/error/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Test"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류, 관리자에게 문의하세요"),
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 엔티티를 찾을 수 없습니다."),
+    BAD_CREDENTIALS(HttpStatus.UNAUTHORIZED, "잘못된 인증 정보입니다"),
 
 
     //Auth
@@ -31,7 +32,7 @@ public enum ErrorCode {
     PASSWORD_NOT_MATCHES(HttpStatus.BAD_REQUEST, "비밀번호를 잘못 입력하셨습니다."),
 
     //User
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 직업을 찾을 수 없습니다"),
     ONBOARD_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 온보딩 상태를 찾을 수 없습니다. (잘못된 온보딩 상태를 입력하셨습니다)"),
 

--- a/src/main/java/com/server/ggini/global/security/AuthConstants.java
+++ b/src/main/java/com/server/ggini/global/security/AuthConstants.java
@@ -1,0 +1,13 @@
+package com.server.ggini.global.security;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class AuthConstants {
+
+    public static final String AUTH_HEADER = "Authorization";
+    public static final String TOKEN_TYPE = "BEARER";
+    public static final String REFRESH_TOKEN_HEADER = "RefreshToken";
+
+}

--- a/src/main/java/com/server/ggini/global/security/JwtUtil.java
+++ b/src/main/java/com/server/ggini/global/security/JwtUtil.java
@@ -1,10 +1,7 @@
 package com.server.ggini.global.security;
 
 import com.server.ggini.domain.member.domain.Member;
-import com.server.ggini.domain.member.domain.MemberRole;
 import com.server.ggini.global.properties.jwt.JwtProperties;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;

--- a/src/main/java/com/server/ggini/global/security/JwtUtil.java
+++ b/src/main/java/com/server/ggini/global/security/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.server.ggini.global.security;
 
+import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.domain.member.domain.MemberRole;
 import com.server.ggini.global.properties.jwt.JwtProperties;
 import io.jsonwebtoken.Claims;
@@ -20,31 +21,31 @@ public class JwtUtil {
     public static final String TOKEN_ROLE_NAME = "role";
     private final JwtProperties jwtProperties;
 
-    public String generateAccessToken(Long memberId, MemberRole role) {
+    public String generateAccessToken(Member member) {
         Date issuedAt = new Date();
         Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
         return Jwts.builder()
-            .setIssuer(jwtProperties.issuer())
-            .setSubject(memberId.toString())
-            .claim(TOKEN_ROLE_NAME, role.getValue())
-            .setIssuedAt(issuedAt)
-            .setExpiration(expiredAt)
-            .signWith(getAccessTokenKey())
-            .compact();
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(member.getId().toString())
+                .claim(TOKEN_ROLE_NAME, member.getRole().getValue())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getAccessTokenKey())
+                .compact();
     }
 
-    public String generateRefreshToken(Long memberId, MemberRole role) {
+    public String generateRefreshToken(Member member) {
         Date issuedAt = new Date();
         Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
 
         return Jwts.builder()
-            .setIssuer(jwtProperties.issuer())
-            .setSubject(memberId.toString())
-            .claim(TOKEN_ROLE_NAME, role.getValue())
-            .setIssuedAt(issuedAt)
-            .setExpiration(expiredAt)
-            .signWith(getRefreshTokenKey())
-            .compact();
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(member.getId().toString())
+                .claim(TOKEN_ROLE_NAME, member.getRole().getValue())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getRefreshTokenKey())
+                .compact();
     }
 
     private Key getAccessTokenKey() {

--- a/src/main/java/com/server/ggini/global/security/filter/EmailPasswordAuthenticationFilter.java
+++ b/src/main/java/com/server/ggini/global/security/filter/EmailPasswordAuthenticationFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -27,7 +28,7 @@ public class EmailPasswordAuthenticationFilter extends UsernamePasswordAuthentic
             final AdminLoginRequest loginRequest = new ObjectMapper().readValue(request.getInputStream(), AdminLoginRequest.class);
             authRequest = UsernamePasswordAuthenticationToken.unauthenticated(loginRequest.email(), loginRequest.password());
         } catch (IOException exception) {
-            throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
+            throw new BadCredentialsException(ErrorCode.INVALID_INPUT_VALUE.getMessage());
         }
         setDetails(request, authRequest);
         return this.getAuthenticationManager().authenticate(authRequest);

--- a/src/main/java/com/server/ggini/global/security/filter/EmailPasswordAuthenticationFilter.java
+++ b/src/main/java/com/server/ggini/global/security/filter/EmailPasswordAuthenticationFilter.java
@@ -1,0 +1,35 @@
+package com.server.ggini.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.ggini.domain.auth.dto.request.AdminLoginRequest;
+import com.server.ggini.global.error.exception.ErrorCode;
+import com.server.ggini.global.error.exception.NotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class EmailPasswordAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    public EmailPasswordAuthenticationFilter(final AuthenticationManager authenticationManager) {
+        super.setAuthenticationManager(authenticationManager);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+        throws AuthenticationException {
+        final UsernamePasswordAuthenticationToken authRequest;
+        try {
+            final AdminLoginRequest loginRequest = new ObjectMapper().readValue(request.getInputStream(), AdminLoginRequest.class);
+            authRequest = UsernamePasswordAuthenticationToken.unauthenticated(loginRequest.email(), loginRequest.password());
+        } catch (IOException exception) {
+            throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
+        }
+        setDetails(request, authRequest);
+        return this.getAuthenticationManager().authenticate(authRequest);
+    }
+}

--- a/src/main/java/com/server/ggini/global/security/handler/EmailPasswordSuccessHandler.java
+++ b/src/main/java/com/server/ggini/global/security/handler/EmailPasswordSuccessHandler.java
@@ -1,0 +1,29 @@
+package com.server.ggini.global.security.handler;
+
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.global.security.AuthConstants;
+import com.server.ggini.global.security.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailPasswordSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void onAuthenticationSuccess(final HttpServletRequest request, final HttpServletResponse response,
+                                        final Authentication authentication) {
+        Member member = (Member) authentication.getPrincipal();
+        String accessToken = jwtUtil.generateAccessToken(member);
+        String refreshToken = jwtUtil.generateRefreshToken(member);
+        response.addHeader(AuthConstants.AUTH_HEADER, AuthConstants.TOKEN_TYPE + " " + accessToken);
+        response.addHeader(AuthConstants.REFRESH_TOKEN_HEADER, AuthConstants.TOKEN_TYPE + " " + refreshToken);
+    }
+
+}

--- a/src/main/java/com/server/ggini/global/security/provider/EmailPasswordAuthenticationProvider.java
+++ b/src/main/java/com/server/ggini/global/security/provider/EmailPasswordAuthenticationProvider.java
@@ -1,0 +1,43 @@
+package com.server.ggini.global.security.provider;
+
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.domain.member.service.MemberService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@RequiredArgsConstructor
+public class EmailPasswordAuthenticationProvider implements AuthenticationProvider {
+
+    private final MemberService memberService;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Override
+    public Authentication authenticate(final Authentication authentication) throws AuthenticationException {
+        final UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken) authentication;
+        final String memberEmail = token.getName();
+        final String memberPassword = (String) token.getCredentials();
+
+        Member member = memberService.getMemberByEmail(memberEmail);
+        if (!memberPassword.equals(member.getPassword())) {
+            throw new BadCredentialsException(member.getEmail() + "Invalid password");
+        }
+
+        return UsernamePasswordAuthenticationToken.authenticated(
+                member,
+                memberPassword,
+                List.of(new SimpleGrantedAuthority(member.getRole().getValue())
+        ));
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+}

--- a/src/main/java/com/server/ggini/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/server/ggini/global/security/provider/JwtTokenProvider.java
@@ -1,9 +1,11 @@
-package com.server.ggini.global.security;
+package com.server.ggini.global.security.provider;
 
 import com.server.ggini.domain.auth.domain.RefreshToken;
 import com.server.ggini.domain.auth.dto.response.TokenPairResponse;
 import com.server.ggini.domain.auth.repository.RefreshTokenRepository;
+import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.domain.member.domain.MemberRole;
+import com.server.ggini.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,19 +17,19 @@ public class JwtTokenProvider {
     private final RefreshTokenRepository refreshTokenRepository;
 
 
-    public TokenPairResponse generateTokenPair(Long memberId, MemberRole memberRole) {
-        String accessToken = createAccessToken(memberId, memberRole);
-        String refreshToken = createRefreshToken(memberId, memberRole);
+    public TokenPairResponse generateTokenPair(Member member) {
+        String accessToken = createAccessToken(member);
+        String refreshToken = createRefreshToken(member);
         return TokenPairResponse.of(accessToken, refreshToken);
     }
 
-    private String createAccessToken(Long memberId, MemberRole memberRole) {
-        return jwtUtil.generateAccessToken(memberId, memberRole);
+    private String createAccessToken(Member member) {
+        return jwtUtil.generateAccessToken(member);
     }
 
-    private String createRefreshToken(Long memberId, MemberRole memberRole) {
-        String token = jwtUtil.generateRefreshToken(memberId, memberRole);
-        saveRefreshToken(memberId, token);
+    private String createRefreshToken(Member member) {
+        String token = jwtUtil.generateRefreshToken(member);
+        saveRefreshToken(member.getId(), token);
         return token;
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,6 +2,17 @@ spring:
   config:
     activate:
       on-profile: local
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
   jpa:
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     active: ${profile}
     group:
       test: "test"
-      local: "local, datasource"
+      local: "local"
       dev: "dev, datasource"
       prod: "prod, datasource"
     include:

--- a/src/test/java/com/server/ggini/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/server/ggini/domain/auth/controller/AuthControllerTest.java
@@ -7,7 +7,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.server.ggini.domain.auth.dto.request.AdminLoginRequest;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -41,30 +44,73 @@ class AuthControllerTest {
                 .apply(springSecurity()).build();
     }
 
-    @Test
-    void 어드민_로그인_성공() throws Exception {
+    @Nested
+    class 어드민_로그인 {
 
-        AdminLoginRequest request = new AdminLoginRequest("admin@example.com", "password123"); // DTO 객체 생성
-        String requestBody = objectMapper.writeValueAsString(request);
+        @Test
+        void 성공() throws Exception {
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/admin/login")
-                        .contentType("application/json")
-                        .content(requestBody))
-                .andExpect(status().isOk()) // 200 응답 확인
-                .andExpect(header().exists("Authorization"))
-                .andExpect(header().exists("RefreshToken"));
+            AdminLoginRequest request = new AdminLoginRequest("admin@example.com", "password123"); // DTO 객체 생성
+            String requestBody = objectMapper.writeValueAsString(request);
 
-    }
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/admin/login")
+                            .contentType("application/json")
+                            .content(requestBody))
+                    .andExpect(status().isOk()) // 200 응답 확인
+                    .andExpect(header().exists("Authorization"))
+                    .andExpect(header().exists("RefreshToken"));
 
-    @Test
-    void 어드민_로그인_실패() throws Exception {
+        }
 
-        AdminLoginRequest request = new AdminLoginRequest("admin@example.com", "wrong123"); // DTO 객체 생성
-        String requestBody = objectMapper.writeValueAsString(request);
+        @Test
+        void 잘못된_요청_본문() throws Exception {
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/admin/login")
-                        .contentType("application/json")
-                        .content(requestBody))
-                .andExpect(status().isUnauthorized()); // 401 응답 확인
+            record TempRecord(String data) {
+            }
+
+            TempRecord request = new TempRecord("임시 테스트 요청 본문");
+            String requestBody = objectMapper.writeValueAsString(request);
+
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/admin/login")
+                            .contentType("application/json")
+                            .content(requestBody))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "plainaddress",              // 이메일 형식이 아님
+                "@missingusername.com",      // 사용자명 없음
+                "username@.com",             // 도메인 이름 없음
+                "username@com",              // 잘못된 도메인
+                "username@domain..com",      // 연속된 점
+                "username@domain,com",       // 쉼표 포함
+                "username@domain space.com", // 공백 포함
+                "username@domain.com space", // 공백 포함
+                "username@domain#com",       // 특수문자 포함
+                ""                           // 빈 문자열
+        })
+        void 잘못된_이메일_양식(String email) throws Exception {
+
+            AdminLoginRequest request = new AdminLoginRequest(email, "password123");
+            String requestBody = objectMapper.writeValueAsString(request);
+
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/admin/login")
+                            .contentType("application/json")
+                            .content(requestBody))
+                    .andExpect(status().isUnauthorized()); // 401 응답 확인
+        }
+
+        @Test
+        void 실패() throws Exception {
+
+            AdminLoginRequest request = new AdminLoginRequest("admin@example.com", "wrong123");
+            String requestBody = objectMapper.writeValueAsString(request);
+
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/admin/login")
+                            .contentType("application/json")
+                            .content(requestBody))
+                    .andExpect(status().isUnauthorized()); // 401 응답 확인
+        }
     }
 }

--- a/src/test/java/com/server/ggini/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/server/ggini/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,70 @@
+package com.server.ggini.domain.auth.controller;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.server.ggini.domain.auth.dto.request.AdminLoginRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql({"/auth-test-data.sql"})
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @BeforeEach
+    public void setMockMvc() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity()).build();
+    }
+
+    @Test
+    void 어드민_로그인_성공() throws Exception {
+
+        AdminLoginRequest request = new AdminLoginRequest("admin@example.com", "password123"); // DTO 객체 생성
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/admin/login")
+                        .contentType("application/json")
+                        .content(requestBody))
+                .andExpect(status().isOk()) // 200 응답 확인
+                .andExpect(header().exists("Authorization"))
+                .andExpect(header().exists("RefreshToken"));
+
+    }
+
+    @Test
+    void 어드민_로그인_실패() throws Exception {
+
+        AdminLoginRequest request = new AdminLoginRequest("admin@example.com", "wrong123"); // DTO 객체 생성
+        String requestBody = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/auth/admin/login")
+                        .contentType("application/json")
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized()); // 401 응답 확인
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     show-sql: true
 
   datasource:

--- a/src/test/resources/auth-test-data.sql
+++ b/src/test/resources/auth-test-data.sql
@@ -1,0 +1,3 @@
+INSERT INTO member (deleted, created_at, update_at, member_id, nickname, email, name, password, role)
+VALUES (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 1, '테스트토끼', 'admin@example.com', 'test', 'password123', 'ADMIN');
+


### PR DESCRIPTION
## 🌱 관련 이슈
- close #8 

## 📌 작업 내용 및 특이사항

Spring Security의 filter단에서 아이디 비밀번호 인증을 구현하였습니다.

로그인 요청 방식에 따른 보안 고민이 있었는데요.

생각되는 로그인 인증 방식에는 2가지가 있었습니다.

1. 로그인 Service를 만들기
    1. login 서비스에서 아이디와 비밀번호를 dto로 받음
    2. 아이디에 해당하는 계정을 db에서 가져옴
    3. 비밀번호 체크를 하고 맞으면 token create 아니면 에러 

2. Spring Security Filter에서 인증하기
    Dispatcher Servlet 안에 들어가기 전에 filter에서 인증처리하기


[결론]
인증되지 않은 사용자의 요청이라면 어떤 악의적 의도가 있을 수 있음.

비지니스 로직들이 처리되는 스프링 컨테이너에 들이오기 전에 검증하고 차단하는 것이 바람직함.

근데 회원가입은 어쩔 수 없이 인증없이 받아야되는거 아닌가?

따라서 회원가입은 아래와 같은 추가 보안을 고려해야함
a.  입력값 검증: 회원가입 폼에서 받은 데이터를 철저히 검증해야 SQL Injection이나 XSS 같은 공격을 방지 가능
b.  CSRF 보호: 만약 CSRF를 활성화한 상태라면, 회원가입 요청에서도 CSRF 토큰을 확인하도록 설정
c.  Rate Limiting: 동일 IP에서 과도한 회원가입 요청을 막기 위해 Rate Limiting을 적용하면 좋음
d.  캡차(Captcha): 자동화된 봇의 악용을 방지하기 위해 회원가입 시 캡차를 도입하는 것도 좋은 방법

그럼 로그인에도 똑같이 하면 되는거 아닌가?

인증의 책임은 누가 가지는가를 고민해본다면 spring security에 인증 책임을 몰아주는 것이 맞다고 판단.

구현 난이도와 시간에 따라서 1번안을 선택할 수도 있겠지만 시간이 있으니 2번으로 구현해보자 생각했습니다.

[참고한 아키텍처]
![image](https://github.com/user-attachments/assets/7df28ed1-503d-478a-82cf-cc1d657f3ad9)
참고한 아키텍처는 위와 같습니다.

추후에 로그인 상태 유지를 위해 Jwt 토큰 인증도 필요하기 때문에 저희 서비스는 1. 아이디, 비밀번호 인증, 2. jwt 인증 2가지가 필요했습니다.
인증 개수가 여러개일 때는 각 인증 구현은 AuthenticationProvider 객체가 하고 Provider 관리는 AuthenticationManager에게 위임하는 Security의 아키텍처를 사용하기로 하였습니다.  [참고]( https://velog.io/@10000ji_/Spring-Security-Authentication-Provider-%EC%9D%B8%EC%A6%9D-%EC%A0%9C%EA%B3%B5%EC%9E%90-%EC%84%A4%EB%AA%85-%EB%B0%8F-%EA%B5%AC%ED%98%84)

하지만 참고 링크의 블로그를 보고 memberService와 Member 엔티티가 있는데 UserDetailsService나 UserDetails를 만들어야하는 것이 마음에 들지 않았습니다. [참고](https://velog.io/@slolee/Spring-Security-%EA%B7%B8%EB%A0%87%EA%B2%8C-%EC%93%B0%EC%A7%80-%EB%A7%88%EC%84%B8%EC%9A%94)

![image](https://github.com/user-attachments/assets/87d1bd1e-5b8e-45a0-a5d8-b5b108949b5e)
따라서 AuthenticationProvider를 구현하는 EmailPasswordAuthenticationProvider를 만들어 UserDetailsService나 UserDetails를 사용하지않고 memberService와 Member 엔티티를 사용하도록 구현하였습니다.
그리고 이를 제외한 나머지 객체는 Spring Security가 제공하는 기본 객체를 사용하였습니다.

[전체 흐름도]
![image](https://github.com/user-attachments/assets/77b95e4a-648d-4f27-b082-2fd773485e77)
filter는 단순히 AuthenticationManager에게 인증할 정보를 담아 전달하고
authenticationManager는 가지고 있는 AuthenticationProvider들에게 인증을 맡기는 형태입니다.
인증이 성공하면 filter는 successHandler에게 성공처리를 맡깁니다.
인증이 실패해 예외가 발생하면 AuthenticationEntryPoint가 예외를 처리합니다.


## 📝 테스트 사항
- mockMvc를 사용하여 통합 테스트로 성공, 실패 케이스 2가지를 테스트하였습니다.


