### PR TITLE
[hotfix/#11] 카카오 로그인 토큰 정보 header로 이동

### DIFF
--- a/src/main/java/com/server/ggini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/server/ggini/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.server.ggini.domain.auth.controller;
 
 import com.server.ggini.domain.auth.dto.request.AdminLoginRequest;
 import com.server.ggini.domain.auth.dto.response.LoginResponse;
+import com.server.ggini.domain.auth.dto.response.MemberSignUpResponse;
 import com.server.ggini.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,6 +13,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,16 +30,48 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "소셜 로그인으로 회원가입", description = "소셜 로그인 후 토큰과 회원 정보를 발급합니다.")
+    @Operation(
+            summary = "소셜 로그인으로 회원가입",
+            description = "소셜 로그인 후 Authorization 토큰과 회원 정보를 발급합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "회원가입 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = MemberSignUpResponse.class)
+                            ),
+                            headers = {
+                                    @Header(name = "Authorization", description = "Access Token", schema = @Schema(type = "string")),
+                                    @Header(name = "RefreshToken", description = "Refresh Token", schema = @Schema(type = "string"))
+                            }
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청",
+                            content = @Content(mediaType = "application/json")
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 오류",
+                            content = @Content(mediaType = "application/json")
+                    )
+            }
+    )
     @PostMapping("/oauth/social-login")
-    public ResponseEntity<LoginResponse> socialLogin(
+    public ResponseEntity<MemberSignUpResponse> socialLogin(
             @RequestHeader("social_access_token") String accessToken,
             @RequestParam("provider")
             @Parameter(example = "kakao", description = "OAuth 제공자")
             String provider
     ) {
         LoginResponse response = authService.socialLogin(accessToken, provider);
-        return ResponseEntity.ok(response);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", response.accessToken());
+        headers.set("RefreshToken", response.refreshToken());
+
+        return new ResponseEntity<>(MemberSignUpResponse.of(response), headers,
+                HttpStatus.OK);
     }
 
     @Operation(summary = "어드민 로그인", description = "아아디 패스워드 로그인 후 토큰 발급합니다.")

--- a/src/main/java/com/server/ggini/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/response/LoginResponse.java
@@ -5,11 +5,12 @@ import com.server.ggini.domain.member.domain.Member;
 public record LoginResponse(
     Long memberId,
     String nickname,
+    String email,
     String accessToken,
     String refreshToken
 ) {
 
     public static LoginResponse of(Member member, TokenPairResponse tokenPairResponse) {
-        return new LoginResponse(member.getId(), member.getNickname(), tokenPairResponse.accessToken(), tokenPairResponse.refreshToken());
+        return new LoginResponse(member.getId(), member.getNickname(), member.getEmail(), tokenPairResponse.accessToken(), tokenPairResponse.refreshToken());
     }
 }

--- a/src/main/java/com/server/ggini/domain/auth/dto/response/MemberSignUpResponse.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/response/MemberSignUpResponse.java
@@ -1,0 +1,12 @@
+package com.server.ggini.domain.auth.dto.response;
+
+public record MemberSignUpResponse(
+    Long memberId,
+    String nickname,
+    String email
+) {
+
+    public static MemberSignUpResponse of(LoginResponse loginResponse) {
+        return new MemberSignUpResponse(loginResponse.memberId(), loginResponse.nickname(), loginResponse.email());
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #11 

## 📌 작업 내용 및 특이사항
<img width="1408" alt="image" src="https://github.com/user-attachments/assets/340110b6-9f58-4bd2-bc7a-c94755c8d249" />

- 카카오 로그인 후 생성한 AT와 RT를 헤더로 옮겼습니다.
- 응답에 email을 추가했습니다.
