### PR TITLE
Feature/#10 jwt 인증 필터를 구현하고 내 정보 조회 api 를 추가하였습니다.

### DIFF
--- a/src/main/java/com/server/ggini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/server/ggini/domain/auth/service/AuthService.java
@@ -7,6 +7,8 @@ import com.server.ggini.domain.auth.service.kakao.KakaoClient;
 import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.domain.member.domain.OauthInfo;
 import com.server.ggini.domain.member.service.MemberService;
+import com.server.ggini.global.security.provider.JwtTokenProvider;
+import com.server.ggini.global.security.utils.JwtTokenGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +19,7 @@ public class AuthService {
 
     private final KakaoClient kakaoClient;
     private final MemberService memberService;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenGenerator jwtTokenGenerator;
 
     @Transactional
     public LoginResponse socialLogin(String socialAccessToken, String provider) {
@@ -26,7 +28,7 @@ public class AuthService {
 
         Member member = memberService.getMemberByOAuthInfo(oauthInfo);
 
-        TokenPairResponse tokenPairResponse = jwtTokenProvider.generateTokenPair(member);
+        TokenPairResponse tokenPairResponse = jwtTokenGenerator.generateTokenPair(member);
         return LoginResponse.of(member, tokenPairResponse);
     }
 

--- a/src/main/java/com/server/ggini/domain/auth/service/AuthService.java
+++ b/src/main/java/com/server/ggini/domain/auth/service/AuthService.java
@@ -7,7 +7,6 @@ import com.server.ggini.domain.auth.service.kakao.KakaoClient;
 import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.domain.member.domain.OauthInfo;
 import com.server.ggini.domain.member.service.MemberService;
-import com.server.ggini.global.security.provider.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/server/ggini/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/ggini/domain/member/controller/MemberController.java
@@ -1,0 +1,23 @@
+package com.server.ggini.domain.member.controller;
+
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.domain.member.dto.response.MemberGetResponse;
+import com.server.ggini.global.annotation.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+    @GetMapping("me")
+    public ResponseEntity<MemberGetResponse> getMyInfo(
+            @AuthUser Member member
+            ) {
+        return ResponseEntity.ok(MemberGetResponse.of(member));
+    }
+}

--- a/src/main/java/com/server/ggini/domain/member/dto/response/MemberGetResponse.java
+++ b/src/main/java/com/server/ggini/domain/member/dto/response/MemberGetResponse.java
@@ -1,0 +1,17 @@
+package com.server.ggini.domain.member.dto.response;
+
+import com.server.ggini.domain.member.domain.Member;
+
+public record MemberGetResponse(
+        Long id,
+        String nickname,
+        String email
+) {
+    public static MemberGetResponse of(Member member) {
+        return new MemberGetResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getEmail()
+        );
+    }
+}

--- a/src/main/java/com/server/ggini/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/server/ggini/domain/member/repository/MemberRepository.java
@@ -16,4 +16,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     default Member findByEmailOrThrow(String email) {
         return findByEmail(email).orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
     }
+
+    default Member findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/server/ggini/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/ggini/domain/member/service/MemberService.java
@@ -30,7 +30,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public Member getMemberByEmail(String email) {
+    public Member getMemberByEmail(String email) throws Exception{
         return memberRepository.findByEmailOrThrow(email);
     }
 

--- a/src/main/java/com/server/ggini/domain/member/service/MemberService.java
+++ b/src/main/java/com/server/ggini/domain/member/service/MemberService.java
@@ -33,4 +33,9 @@ public class MemberService {
     public Member getMemberByEmail(String email) {
         return memberRepository.findByEmailOrThrow(email);
     }
+
+    @Transactional(readOnly = true)
+    public Member getMemberById(Long id) {
+        return memberRepository.findByIdOrThrow(id);
+    }
 }

--- a/src/main/java/com/server/ggini/global/annotation/AuthUser.java
+++ b/src/main/java/com/server/ggini/global/annotation/AuthUser.java
@@ -1,0 +1,12 @@
+package com.server.ggini.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthUser {
+
+}

--- a/src/main/java/com/server/ggini/global/annotation/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/server/ggini/global/annotation/AuthenticationArgumentResolver.java
@@ -1,10 +1,10 @@
 package com.server.ggini.global.annotation;
 
-import com.server.backyaserver.domain.member.domain.Member;
-import com.server.backyaserver.domain.member.repository.MemberRepository;
-import com.server.backyaserver.global.error.exception.BusinessException;
-import com.server.backyaserver.global.error.exception.ErrorCode;
-import com.server.backyaserver.global.error.exception.NotFoundException;
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.domain.member.repository.MemberRepository;
+import com.server.ggini.global.error.exception.BusinessException;
+import com.server.ggini.global.error.exception.ErrorCode;
+import com.server.ggini.global.error.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/server/ggini/global/annotation/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/server/ggini/global/annotation/AuthenticationArgumentResolver.java
@@ -1,0 +1,54 @@
+package com.server.ggini.global.annotation;
+
+import com.server.backyaserver.domain.member.domain.Member;
+import com.server.backyaserver.domain.member.repository.MemberRepository;
+import com.server.backyaserver.global.error.exception.BusinessException;
+import com.server.backyaserver.global.error.exception.ErrorCode;
+import com.server.backyaserver.global.error.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberRepository memberRepository;
+
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        final boolean isUserAuthAnnotation = parameter.getParameterAnnotation(AuthUser.class) != null;
+        final boolean isMemberClass = parameter.getParameterType().equals(Member.class);
+        return isUserAuthAnnotation && isMemberClass;
+    }
+
+    @Override
+    public Member resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return getCurrentMember();
+    }
+
+    private Member getCurrentMember() {
+        return memberRepository
+            .findById(getCurrentMemberId())
+            .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new BusinessException(ErrorCode.AUTH_NOT_FOUND);
+        }
+
+        Member principal = (Member) authentication.getPrincipal();
+        return principal.getId();
+    }
+}

--- a/src/main/java/com/server/ggini/global/config/WebConfig.java
+++ b/src/main/java/com/server/ggini/global/config/WebConfig.java
@@ -1,0 +1,30 @@
+package com.server.ggini.global.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+@EnableTransactionManagement
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${cors-allowed-origins}")
+    private List<String> corsAllowedOrigins;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins(corsAllowedOrigins.toArray(new String[0]))
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+    }
+
+}

--- a/src/main/java/com/server/ggini/global/config/WebConfig.java
+++ b/src/main/java/com/server/ggini/global/config/WebConfig.java
@@ -1,11 +1,13 @@
 package com.server.ggini.global.config;
 
+import com.server.ggini.global.annotation.AuthenticationArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -14,6 +16,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 @EnableTransactionManagement
 public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthenticationArgumentResolver authenticationArgumentResolver;
 
     @Value("${cors-allowed-origins}")
     private List<String> corsAllowedOrigins;
@@ -27,4 +31,8 @@ public class WebConfig implements WebMvcConfigurer {
             .allowCredentials(true);
     }
 
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationArgumentResolver);
+    }
 }

--- a/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
@@ -37,8 +37,6 @@ public class SecurityConfig {
     private final MemberService memberService;
     private final EmailPasswordSuccessHandler emailPasswordSuccessHandler;
     private final JwtUtil jwtUtil;
-    private final AuthenticationConfiguration authenticationConfiguration;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     private String[] allowUrls = {"/", "/favicon.ico",
         "/api/v1/auth/oauth/**", "/swagger-ui/**", "/v3/**"};
@@ -71,6 +69,7 @@ public class SecurityConfig {
         authenticationManagerBuilder
                 .authenticationProvider(emailPasswordAuthenticationProvider())
                 .authenticationProvider(jwtTokenProvider());
+        authenticationManagerBuilder.parentAuthenticationManager(null);
         return authenticationManagerBuilder.build();
     }
 
@@ -110,6 +109,8 @@ public class SecurityConfig {
                 .exceptionHandling(exception ->
                         exception.authenticationEntryPoint((request, response, authException) ->
                                 response.setStatus(HttpStatus.UNAUTHORIZED.value())));
+
+        http.authenticationManager(authenticationManager(http));
 
         http
                 .addFilterAt(emailPasswordAuthenticationFilter(authenticationManager(http)), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
@@ -2,9 +2,9 @@ package com.server.ggini.global.config.security;
 
 import com.server.ggini.domain.member.service.MemberService;
 import com.server.ggini.global.security.handler.EmailPasswordSuccessHandler;
-import com.server.ggini.global.security.provider.JwtTokenProvider;
 import com.server.ggini.global.security.filter.EmailPasswordAuthenticationFilter;
 import com.server.ggini.global.security.provider.EmailPasswordAuthenticationProvider;
+import com.server.ggini.global.security.provider.JwtTokenProvider;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -87,6 +87,7 @@ public class SecurityConfig {
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         ProviderManager providerManager = (ProviderManager) authenticationConfiguration.getAuthenticationManager();
         providerManager.getProviders().add(emailPasswordAuthenticationProvider());
+        providerManager.getProviders().add(jwtTokenProvider);
         return configuration.getAuthenticationManager();
     }
 

--- a/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
@@ -1,10 +1,12 @@
 package com.server.ggini.global.config.security;
 
 import com.server.ggini.domain.member.service.MemberService;
+import com.server.ggini.global.security.filter.JwtAuthenticationFilter;
 import com.server.ggini.global.security.handler.EmailPasswordSuccessHandler;
 import com.server.ggini.global.security.filter.EmailPasswordAuthenticationFilter;
 import com.server.ggini.global.security.provider.EmailPasswordAuthenticationProvider;
 import com.server.ggini.global.security.provider.JwtTokenProvider;
+import com.server.ggini.global.security.utils.JwtUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +15,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -33,8 +36,9 @@ public class SecurityConfig {
 
     private final MemberService memberService;
     private final EmailPasswordSuccessHandler emailPasswordSuccessHandler;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtUtil jwtUtil;
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     private String[] allowUrls = {"/", "/favicon.ico",
         "/api/v1/auth/oauth/**", "/swagger-ui/**", "/v3/**"};
@@ -42,60 +46,35 @@ public class SecurityConfig {
     @Value("${cors-allowed-origins}")
     private List<String> corsAllowedOrigins;
 
+    // 1. Password encoder
     @Bean
-    public WebSecurityCustomizer configure() {
-        // filter 안타게 무시
-        return (web) -> web.ignoring().requestMatchers(allowUrls);
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
-
-
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-            .csrf(AbstractHttpConfigurer::disable)
-            .formLogin(AbstractHttpConfigurer::disable)
-            .cors(customizer -> customizer.configurationSource(corsConfigurationSource()))
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(request -> request
-                .requestMatchers(allowUrls).permitAll()
-                .anyRequest().authenticated());
-
-        http
-            .exceptionHandling(exception ->
-                exception.authenticationEntryPoint((request, response, authException) ->
-                    response.setStatus(HttpStatus.UNAUTHORIZED.value()))); // 인증,인가가 되지 않은 요청 시 발생시
-
-        http
-            .addFilterAt(emailPasswordAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
-//            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
-//            .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class);
-
-        return http.build();
-    }
-
-    @Bean
-    public EmailPasswordAuthenticationFilter emailPasswordAuthenticationFilter() throws Exception {
-        EmailPasswordAuthenticationFilter emailPasswordAuthenticationFilter = new EmailPasswordAuthenticationFilter(authenticationManager(authenticationConfiguration));
-        emailPasswordAuthenticationFilter.setFilterProcessesUrl("/api/v1/auth/admin/login");
-        emailPasswordAuthenticationFilter.setAuthenticationSuccessHandler(emailPasswordSuccessHandler);
-        emailPasswordAuthenticationFilter.afterPropertiesSet();
-        return emailPasswordAuthenticationFilter;
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-        ProviderManager providerManager = (ProviderManager) authenticationConfiguration.getAuthenticationManager();
-        providerManager.getProviders().add(emailPasswordAuthenticationProvider());
-        providerManager.getProviders().add(jwtTokenProvider);
-        return configuration.getAuthenticationManager();
-    }
-
+    // 2. AuthenticationProvider
     @Bean
     public EmailPasswordAuthenticationProvider emailPasswordAuthenticationProvider() {
-        return new EmailPasswordAuthenticationProvider(memberService, bCryptPasswordEncoder());
+        return new EmailPasswordAuthenticationProvider(memberService);
     }
 
+    @Bean
+    public JwtTokenProvider jwtTokenProvider() {
+        return new JwtTokenProvider(jwtUtil, memberService);
+    }
+
+    // 3. AuthenticationManager
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder authenticationManagerBuilder =
+                http.getSharedObject(AuthenticationManagerBuilder.class);
+        authenticationManagerBuilder
+                .authenticationProvider(emailPasswordAuthenticationProvider())
+                .authenticationProvider(jwtTokenProvider());
+        return authenticationManagerBuilder.build();
+    }
+
+    // 4. CORS Configuration
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
@@ -109,8 +88,50 @@ public class SecurityConfig {
         return source;
     }
 
+    // 5. Web Security Customizer
     @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder() {
-        return new BCryptPasswordEncoder();
+    public WebSecurityCustomizer configure() {
+        return (web) -> web.ignoring().requestMatchers(allowUrls);
+    }
+
+    // 6. SecurityFilterChain
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .cors(customizer -> customizer.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers(allowUrls).permitAll()
+                        .anyRequest().authenticated());
+
+        http
+                .exceptionHandling(exception ->
+                        exception.authenticationEntryPoint((request, response, authException) ->
+                                response.setStatus(HttpStatus.UNAUTHORIZED.value())));
+
+        http
+                .addFilterAt(emailPasswordAuthenticationFilter(authenticationManager(http)), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter(authenticationManager(http)), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    // 7. EmailPasswordAuthenticationFilter
+    @Bean
+    public EmailPasswordAuthenticationFilter emailPasswordAuthenticationFilter(AuthenticationManager authenticationManager) throws Exception {
+        EmailPasswordAuthenticationFilter filter = new EmailPasswordAuthenticationFilter(authenticationManager);
+        filter.setFilterProcessesUrl("/api/v1/auth/admin/login");
+        filter.setAuthenticationSuccessHandler(emailPasswordSuccessHandler);
+        filter.afterPropertiesSet();
+        return filter;
+    }
+
+    // 8. JwtAuthenticationFilter
+    public JwtAuthenticationFilter jwtAuthenticationFilter(AuthenticationManager authenticationManager) throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(authenticationManager);
+        filter.afterPropertiesSet();
+        return filter;
     }
 }

--- a/src/main/java/com/server/ggini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/server/ggini/global/error/exception/ErrorCode.java
@@ -16,8 +16,7 @@ public enum ErrorCode {
     //Auth
     AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "시큐리티 인증 정보를 찾을 수 없습니다."),
     UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "알 수 없는 에러"),
-    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 access Token입니다"),
-    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 refresh Token입니다. 재로그인하세요"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 Token입니다"),
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 길이 및 형식이 다른 Token입니다"),
     WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "서명이 잘못된 토큰입니다."),
     ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "토큰이 없습니다"),

--- a/src/main/java/com/server/ggini/global/security/JwtUtil.java
+++ b/src/main/java/com/server/ggini/global/security/JwtUtil.java
@@ -2,12 +2,15 @@ package com.server.ggini.global.security;
 
 import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.global.properties.jwt.JwtProperties;
+import com.server.ggini.global.security.token.JwtAuthenticationToken;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -43,6 +46,16 @@ public class JwtUtil {
                 .setExpiration(expiredAt)
                 .signWith(getRefreshTokenKey())
                 .compact();
+    }
+
+    public Claims getAccessTokenClaims(Authentication authentication) {
+
+        return Jwts.parserBuilder()
+                .requireIssuer(jwtProperties.issuer())
+                .setSigningKey(getAccessTokenKey())
+                .build()
+                .parseClaimsJws(((JwtAuthenticationToken) authentication).getJsonWebToken())
+                .getBody();
     }
 
     private Key getAccessTokenKey() {

--- a/src/main/java/com/server/ggini/global/security/exception/JwtInvalidException.java
+++ b/src/main/java/com/server/ggini/global/security/exception/JwtInvalidException.java
@@ -1,0 +1,14 @@
+package com.server.ggini.global.security.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtInvalidException extends AuthenticationException {
+
+    public JwtInvalidException(String msg) {
+        super(msg);
+    }
+
+    public JwtInvalidException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/com/server/ggini/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/server/ggini/global/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.server.ggini.global.security.filter;
+
+import com.moplus.moplus_server.global.security.token.JwtAuthenticationToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private final AuthenticationManager authenticationManager;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessToken = extractAccessTokenFromHeader(request);
+
+        if (StringUtils.hasText(accessToken)) {
+            Authentication jwtAuthenticationToken = new JwtAuthenticationToken(accessToken);
+            Authentication authentication = authenticationManager.authenticate(jwtAuthenticationToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+
+    private String extractAccessTokenFromHeader(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader("Authorization"))
+                .filter(header -> header.startsWith(TOKEN_PREFIX))
+                .map(header -> header.replace(TOKEN_PREFIX, ""))
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/server/ggini/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/server/ggini/global/security/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package com.server.ggini.global.security.filter;
 
-import com.moplus.moplus_server.global.security.token.JwtAuthenticationToken;
+import com.server.ggini.global.security.token.JwtAuthenticationToken;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/server/ggini/global/security/handler/EmailPasswordSuccessHandler.java
+++ b/src/main/java/com/server/ggini/global/security/handler/EmailPasswordSuccessHandler.java
@@ -2,7 +2,7 @@ package com.server.ggini.global.security.handler;
 
 import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.global.security.AuthConstants;
-import com.server.ggini.global.security.JwtUtil;
+import com.server.ggini.global.security.utils.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/server/ggini/global/security/provider/EmailPasswordAuthenticationProvider.java
+++ b/src/main/java/com/server/ggini/global/security/provider/EmailPasswordAuthenticationProvider.java
@@ -18,7 +18,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 public class EmailPasswordAuthenticationProvider implements AuthenticationProvider {
 
     private final MemberService memberService;
-    private final BCryptPasswordEncoder passwordEncoder;
 
     @Override
     public Authentication authenticate(final Authentication authentication) throws AuthenticationException {

--- a/src/main/java/com/server/ggini/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/server/ggini/global/security/provider/JwtTokenProvider.java
@@ -3,7 +3,7 @@ package com.server.ggini.global.security.provider;
 import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.domain.member.service.MemberService;
 import com.server.ggini.global.error.exception.ErrorCode;
-import com.server.ggini.global.security.JwtUtil;
+import com.server.ggini.global.security.utils.JwtUtil;
 import com.server.ggini.global.security.exception.JwtInvalidException;
 import com.server.ggini.global.security.token.JwtAuthenticationToken;
 import io.jsonwebtoken.Claims;
@@ -19,7 +19,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 
-@Service
 @RequiredArgsConstructor
 public class JwtTokenProvider implements AuthenticationProvider {
 

--- a/src/main/java/com/server/ggini/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/server/ggini/global/security/provider/JwtTokenProvider.java
@@ -16,7 +16,6 @@ public class JwtTokenProvider {
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
-
     public TokenPairResponse generateTokenPair(Member member) {
         String accessToken = createAccessToken(member);
         String refreshToken = createRefreshToken(member);

--- a/src/main/java/com/server/ggini/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/server/ggini/global/security/provider/JwtTokenProvider.java
@@ -1,44 +1,69 @@
 package com.server.ggini.global.security.provider;
 
-import com.server.ggini.domain.auth.domain.RefreshToken;
-import com.server.ggini.domain.auth.dto.response.TokenPairResponse;
-import com.server.ggini.domain.auth.repository.RefreshTokenRepository;
 import com.server.ggini.domain.member.domain.Member;
-import com.server.ggini.domain.member.domain.MemberRole;
+import com.server.ggini.domain.member.service.MemberService;
+import com.server.ggini.global.error.exception.ErrorCode;
 import com.server.ggini.global.security.JwtUtil;
+import com.server.ggini.global.security.exception.JwtInvalidException;
+import com.server.ggini.global.security.token.JwtAuthenticationToken;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class JwtTokenProvider {
+public class JwtTokenProvider implements AuthenticationProvider {
 
     private final JwtUtil jwtUtil;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberService memberService;
 
-    public TokenPairResponse generateTokenPair(Member member) {
-        String accessToken = createAccessToken(member);
-        String refreshToken = createRefreshToken(member);
-        return TokenPairResponse.of(accessToken, refreshToken);
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        Claims claims = getClaims(authentication);
+        final Member member = getMemberById(claims.getSubject());
+
+        return new JwtAuthenticationToken(
+                member,
+                "",
+                List.of(new SimpleGrantedAuthority(member.getRole().getValue())
+                ));
     }
 
-    private String createAccessToken(Member member) {
-        return jwtUtil.generateAccessToken(member);
-    }
-
-    private String createRefreshToken(Member member) {
-        String token = jwtUtil.generateRefreshToken(member);
-        saveRefreshToken(member.getId(), token);
-        return token;
-    }
-
-    private void saveRefreshToken(Long memberId, String refreshToken) {
-        if(refreshTokenRepository.existsByMemberId(memberId)) {
-            refreshTokenRepository.deleteByMemberId(memberId);
+    private Claims getClaims(Authentication authentication) {
+        Claims claims;
+        try {
+            claims = jwtUtil.getAccessTokenClaims(authentication);
+        } catch (ExpiredJwtException expiredJwtException) {
+            throw new JwtInvalidException(ErrorCode.EXPIRED_TOKEN.getMessage());
+        } catch (SignatureException signatureException) {
+            throw new JwtInvalidException(ErrorCode.WRONG_TYPE_TOKEN.getMessage());
+        } catch (MalformedJwtException malformedJwtException) {
+            throw new JwtInvalidException(ErrorCode.UNSUPPORTED_TOKEN.getMessage());
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw new JwtInvalidException(ErrorCode.UNKNOWN_ERROR.getMessage());
         }
-        refreshTokenRepository.save(RefreshToken.builder()
-                .memberId(memberId)
-                .token(refreshToken)
-                .build());
+        return claims;
+    }
+
+    private Member getMemberById(String id) {
+        try {
+            return memberService.getMemberById(Long.parseLong(id));
+        } catch (Exception e) {
+            throw new BadCredentialsException(ErrorCode.BAD_CREDENTIALS.getMessage());
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
     }
 }

--- a/src/main/java/com/server/ggini/global/security/token/JwtAuthenticationToken.java
+++ b/src/main/java/com/server/ggini/global/security/token/JwtAuthenticationToken.java
@@ -1,0 +1,38 @@
+package com.server.ggini.global.security.token;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private String jsonWebToken;
+    private Object principal;
+    private Object credentials;
+
+    public JwtAuthenticationToken(String jsonWebToken) {
+        super(null);
+        this.jsonWebToken = jsonWebToken;
+        this.setAuthenticated(false);
+    }
+
+    public JwtAuthenticationToken(Object principal, Object credentials,
+                                  Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        super.setAuthenticated(true);
+    }
+
+    public Object getCredentials() {
+        return credentials;
+    }
+
+    public Object getPrincipal() {
+        return this.principal;
+    }
+
+    public String getJsonWebToken() {
+        return this.jsonWebToken;
+    }
+}

--- a/src/main/java/com/server/ggini/global/security/utils/JwtTokenGenerator.java
+++ b/src/main/java/com/server/ggini/global/security/utils/JwtTokenGenerator.java
@@ -1,0 +1,42 @@
+package com.server.ggini.global.security.utils;
+
+import com.server.ggini.domain.auth.domain.RefreshToken;
+import com.server.ggini.domain.auth.dto.response.TokenPairResponse;
+import com.server.ggini.domain.auth.repository.RefreshTokenRepository;
+import com.server.ggini.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenGenerator {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public TokenPairResponse generateTokenPair(Member member) {
+        String accessToken = createAccessToken(member);
+        String refreshToken = createRefreshToken(member);
+        return TokenPairResponse.of(accessToken, refreshToken);
+    }
+
+    private String createAccessToken(Member member) {
+        return jwtUtil.generateAccessToken(member);
+    }
+
+    private String createRefreshToken(Member member) {
+        String token = jwtUtil.generateRefreshToken(member);
+        saveRefreshToken(member.getId(), token);
+        return token;
+    }
+
+    private void saveRefreshToken(Long memberId, String refreshToken) {
+        if(refreshTokenRepository.existsByMemberId(memberId)) {
+            refreshTokenRepository.deleteByMemberId(memberId);
+        }
+        refreshTokenRepository.save(RefreshToken.builder()
+                .memberId(memberId)
+                .token(refreshToken)
+                .build());
+    }
+}

--- a/src/main/java/com/server/ggini/global/security/utils/JwtUtil.java
+++ b/src/main/java/com/server/ggini/global/security/utils/JwtUtil.java
@@ -1,4 +1,4 @@
-package com.server.ggini.global.security;
+package com.server.ggini.global.security.utils;
 
 import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.global.properties.jwt.JwtProperties;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,7 +23,5 @@ management:
     health:
       enabled: true
 
-cors-allowed-origins:
-  http://localhost:8080,
-  http://localhost:3000,
+
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,8 +22,4 @@ spring:
     hibernate:
       ddl-auto: update
 
-cors-allowed-origins:
-  http://localhost:8080,
-  http://localhost:3000,
-
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,8 @@ logging:
   level:
     root: INFO
     org.springframework.security: TRACE
+
+cors-allowed-origins:
+  http://localhost:8080,
+  http://localhost:3000,
+  https://kkini-front.vercel.app

--- a/src/test/java/com/server/ggini/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/server/ggini/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,94 @@
+package com.server.ggini.domain.member.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.domain.member.domain.MemberRole;
+import com.server.ggini.global.properties.jwt.JwtProperties;
+import com.server.ggini.global.security.provider.JwtTokenProvider;
+import com.server.ggini.global.security.token.JwtAuthenticationToken;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.lang.reflect.Field;
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql({"/auth-test-data.sql"})
+class MemberControllerTest {
+
+    @Nested
+    class 어드민_로그인 {
+
+        @Autowired
+        private JwtProperties jwtProperties;
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Autowired
+        private WebApplicationContext context;
+
+        private String validToken;
+        private Key key;
+
+        @BeforeEach
+        public void setMockMvc() throws Exception{
+            this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                    .apply(springSecurity()).build();
+
+            key = Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
+            Date issuedAt = new Date();  // 3 hour ago
+            Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+            validToken = Jwts.builder()
+                    .setIssuer(jwtProperties.issuer())
+                    .setSubject("1")
+                    .claim("role", "ROLE_USER")
+                    .setIssuedAt(issuedAt)
+                    .setExpiration(expiredAt)
+                    .signWith(key)
+                    .compact();
+        }
+
+        @Test
+        void 성공() throws Exception {
+
+
+            mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/member/me")
+                            .contentType("application/json")
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + validToken))
+                    .andExpect(status().isOk()) // 200 응답 확인
+                    .andExpect(jsonPath("$.id").exists()) // MemberGetResponse의 필드 확인
+                    .andExpect(jsonPath("$.nickname").exists())
+                    .andExpect(jsonPath("$.email").exists());
+
+        }
+    }
+}

--- a/src/test/java/com/server/ggini/global/security/utils/JwtUtilTest.java
+++ b/src/test/java/com/server/ggini/global/security/utils/JwtUtilTest.java
@@ -1,0 +1,112 @@
+package com.server.ggini.global.security.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import com.server.ggini.global.properties.jwt.JwtProperties;
+import com.server.ggini.global.security.token.JwtAuthenticationToken;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.security.Key;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtUtilTest {
+
+    @Mock
+    private JwtProperties jwtProperties;
+
+    @InjectMocks
+    private JwtUtil jwtUtil;
+
+    private String validToken;
+    private Key key;
+
+    @BeforeEach
+    public void setup() {
+        // Mock JwtProperties
+        when(jwtProperties.issuer()).thenReturn("testIssuer");
+        when(jwtProperties.accessTokenSecret()).thenReturn(
+                "mySecretKeymySecretKeymySecretKeymySecretKey"); // 256-bit key
+        when(jwtProperties.accessTokenExpirationMilliTime()).thenReturn(7200000L); // 1 hour
+
+        // Generate a test token
+        key = Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
+        Date issuedAt = new Date();  // 3 hour ago
+        Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        validToken = Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject("1")
+                .claim("role", "ROLE_USER")
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(key)
+                .compact();
+    }
+
+    @Test
+    public void 유효한_토큰_통과() {
+
+        Authentication jwtAuthenticationToken = new JwtAuthenticationToken(validToken);
+
+        // Act
+        Claims claimsJws = jwtUtil.getAccessTokenClaims(jwtAuthenticationToken);
+
+        // Assert
+        assertNotNull(claimsJws);
+        assertEquals("testIssuer", claimsJws.getIssuer());
+        assertEquals("1", claimsJws.getSubject());
+        assertEquals("ROLE_USER", claimsJws.get("role", String.class));
+    }
+
+    @Test
+    public void 만료된_토큰_예외() {
+        Date issuedAt = new Date(System.currentTimeMillis() - 10800000L);  // 3 hour ago
+        Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        String expiredToken = Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject("12345")
+                .claim("role", "ROLE_USER")
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt) // 1 hour ago
+                .signWith(key)
+                .compact();
+
+        Authentication jwtAuthenticationToken = new JwtAuthenticationToken(expiredToken);
+
+        assertThrows(ExpiredJwtException.class,
+                () -> jwtUtil.getAccessTokenClaims(jwtAuthenticationToken));
+    }
+
+    @Test
+    public void 조작된_토큰_예외() {
+        //토큰 변형
+        String invalidSignatureToken = validToken.substring(0, validToken.length() - 1) + "@";
+        Authentication jwtAuthenticationToken = new JwtAuthenticationToken(invalidSignatureToken);
+        assertThrows(SignatureException.class, () -> {
+            jwtUtil.getAccessTokenClaims(jwtAuthenticationToken);
+        });
+    }
+
+    @Test
+    public void jwt_토큰_형식이_아닌_토큰_예외() {
+        //형식이 jwt 토큰 형식 조차 아닌 토큰
+        String malformedToken = "malformed.token.here";
+        Authentication jwtAuthenticationToken = new JwtAuthenticationToken(malformedToken);
+        assertThrows(MalformedJwtException.class, () -> {
+            jwtUtil.getAccessTokenClaims(jwtAuthenticationToken);
+        });
+    }
+}

--- a/src/test/resources/auth-test-data.sql
+++ b/src/test/resources/auth-test-data.sql
@@ -1,3 +1,3 @@
-INSERT INTO member (deleted, created_at, update_at, member_id, nickname, email, name, password, role)
-VALUES (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 1, '테스트토끼', 'admin@example.com', 'test', 'password123', 'ADMIN');
+INSERT INTO member (deleted, created_at, update_at, member_id, nickname, email, password, role)
+VALUES (false, '2024-07-24 21:27:20.000000', '2024-07-24 21:27:21.000000', 1, '테스트토끼', 'admin@example.com', 'password123', 'ADMIN');
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #10 

## 📌 작업 내용 및 특이사항
- 저번에 구현한 이메일 패스워드 인증 후 인증 상태 유지를 위해 JwtAuthenticationFilter를 spring security에 추가하였습니다.
- <img width="1564" alt="image" src="https://github.com/user-attachments/assets/fb4a1fc8-e174-469d-9eac-eb80f3aa155a" />
- 빨간 색으로 표시한 부분이 추가 필터 로직입니다.

- 저번에 구성하였던 AuthenticationManger에 AuthenticationProvider를 구현한 JwtTokenProvider를 추가하여 여러개의 인증 Provider 관리 책임은 Manger가 하도록 유지했습니다.
- Jwt를 인증하는 책임은 JwtTokenProvider가 맡습니다.
- Filter의 순서는 JwtAuthenticationFilter -> EmailPasswordAuthenticationFilter 순 입니다. 토큰이 없을 시 다음 이메일 패스워드 필터로 넘어가는 순서입니다. 아무 인증도 없을 시 예외가 발생하고 authenticationEntryPoint가 공통적으로 처리합니다.

## 📝 테스트사항
<img width="293" alt="image" src="https://github.com/user-attachments/assets/5923ed7f-c8b4-4114-bf8b-07795deedf48" />

- jwt유효성 검사가 잘 이우러지는지 테스트를 추가했습니다.
- 기존 로그인 방식의 인증 통합 테스트도 잘 이루어지는 것을 볼 수 있습니다.

## 🎯 트러블 슈팅 
- JwtAuthenticationFilter를 추가하며 기존 로그인 통합테스트가 실패했었습니다.
    - 원인1 : spring security 6.x.x 버전으로 올라오면서 AuthenticationManger 등록방식이 수정되어서 반영하였습니다.
    - 원인2 : 기존 로그인 인증은 jwt토큰이 없는데 여기서 인증이 실패하게 되고 다음 필터로 넘어가야하는데 넘어가지 못하고 다시 jwt인증을 무한 방복하는 이슈가 있었습니다. 
 
    - <img width="693" alt="image" src="https://github.com/user-attachments/assets/2f2a40b5-61d4-43cf-9e2a-566929605010" />

    - ProviderManager는 인증이 실패하면 부모 manger의 authenticate()를 호출하게 되는데 여기서 자기 자신이 부모로 초기화되어 있었습니다.
 AuthenticationManger 등록 방식이 바뀌면서 명시적으로 AuthenticationManger의 parent를 null처리하지 않으면 자기 자신이 부모로 잡히게 됩니다. 명시적으로 null처리 하여 해결하였습니다.


