### PR TITLE
[fix/#15] 소셜 로그인 이메일 잘 뜨게 수정

### DIFF
--- a/src/main/java/com/server/ggini/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/response/LoginResponse.java
@@ -11,6 +11,6 @@ public record LoginResponse(
 ) {
 
     public static LoginResponse of(Member member, TokenPairResponse tokenPairResponse) {
-        return new LoginResponse(member.getId(), member.getNickname(), member.getEmail(), tokenPairResponse.accessToken(), tokenPairResponse.refreshToken());
+        return new LoginResponse(member.getId(), member.getNickname(), member.getOauthInfo().getOauthEmail(), tokenPairResponse.accessToken(), tokenPairResponse.refreshToken());
     }
 }

--- a/src/main/java/com/server/ggini/domain/member/dto/response/MemberGetResponse.java
+++ b/src/main/java/com/server/ggini/domain/member/dto/response/MemberGetResponse.java
@@ -8,10 +8,15 @@ public record MemberGetResponse(
         String email
 ) {
     public static MemberGetResponse of(Member member) {
+        String email = member.getEmail();
+        if (member.getOauthInfo() != null && member.getOauthInfo().getOauthEmail() != null) {
+            email = member.getOauthInfo().getOauthEmail();
+        }
+
         return new MemberGetResponse(
                 member.getId(),
                 member.getNickname(),
-                member.getEmail()
+                email
         );
     }
 }

--- a/src/test/java/com/server/ggini/domain/member/dto/response/MemberGetResponseTest.java
+++ b/src/test/java/com/server/ggini/domain/member/dto/response/MemberGetResponseTest.java
@@ -1,0 +1,66 @@
+package com.server.ggini.domain.member.dto.response;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.domain.member.domain.OauthInfo;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class MemberGetResponseTest {
+
+    @Test
+    void 회원이_OauthInfo를_가질_경우_응답이_정상적으로_생성된다() throws Exception {
+        // given
+        OauthInfo oauthInfo = OauthInfo.builder()
+                .oauthId("test-oauth-id")
+                .oauthProvider("kakao")
+                .oauthEmail("oauth@example.com")
+                .name("Oauth User")
+                .build();
+
+        Member member = Member.builder()
+                .nickname("testUser")
+                .email("default@example.com")
+                .oauthInfo(oauthInfo)
+                .build();
+
+        // Reflection으로 id 설정
+        Field idField = Member.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(member, 1L);
+
+        // when
+        MemberGetResponse response = MemberGetResponse.of(member);
+
+        // then
+        assertNotNull(response);
+        assertEquals(1L, response.id());
+        assertEquals("testUser", response.nickname());
+        assertEquals("oauth@example.com", response.email());
+    }
+
+    @Test
+    void 회원이_OauthInfo를_가지지_않을_경우_응답이_정상적으로_생성된다() throws Exception {
+        // given
+        Member member = Member.builder()
+                .nickname("testUserNoOauth")
+                .email("default@example.com")
+                .build();
+
+        // Reflection으로 id 설정
+        Field idField = Member.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(member, 2L);
+
+        // when
+        MemberGetResponse response = MemberGetResponse.of(member);
+
+        // then
+        assertNotNull(response);
+        assertEquals(2L, response.id());
+        assertEquals("testUserNoOauth", response.nickname());
+        assertEquals("default@example.com", response.email());
+    }
+
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #15 

## 📌 작업 내용 및 특이사항
- 기존 소셜 로그인 가입자가 email이 null로 나오는 이슈를 해결했습니다.

