### PR TITLE
Feature/#22 jwt refreshToken 쿠키 및 프리사인 url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     // DataBase
     runtimeOnly 'com.mysql:mysql-connector-j'
 
-    // Swagger
+    //swagger-ui
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     // JWT

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     //db-h2
     implementation 'com.h2database:h2'
     testImplementation 'com.h2database:h2'
+
+    //s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/server/ggini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/server/ggini/domain/auth/controller/AuthController.java
@@ -4,6 +4,9 @@ import com.server.ggini.domain.auth.dto.request.AdminLoginRequest;
 import com.server.ggini.domain.auth.dto.response.LoginResponse;
 import com.server.ggini.domain.auth.dto.response.MemberSignUpResponse;
 import com.server.ggini.domain.auth.service.AuthService;
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.global.security.AuthConstants;
+import com.server.ggini.global.security.utils.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -11,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.Cookie;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -24,73 +28,32 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class AuthController {
+@RequestMapping("/api/v1/auth")
+public class AuthController implements AuthControllerDocs {
 
     private final AuthService authService;
+    private final CookieUtil cookieUtil;
 
-    @Operation(
-            summary = "소셜 로그인으로 회원가입",
-            description = "소셜 로그인 후 Authorization 토큰과 회원 정보를 발급합니다.",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "회원가입 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = MemberSignUpResponse.class)
-                            ),
-                            headers = {
-                                    @Header(name = "Authorization", description = "Access Token", schema = @Schema(type = "string")),
-                                    @Header(name = "RefreshToken", description = "Refresh Token", schema = @Schema(type = "string"))
-                            }
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "잘못된 요청",
-                            content = @Content(mediaType = "application/json")
-                    ),
-                    @ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류",
-                            content = @Content(mediaType = "application/json")
-                    )
-            }
-    )
+    @Override
     @PostMapping("/oauth/social-login")
     public ResponseEntity<MemberSignUpResponse> socialLogin(
             @RequestHeader("social_access_token") String accessToken,
-            @RequestParam("provider")
-            @Parameter(example = "kakao", description = "OAuth 제공자")
-            String provider
+            @RequestParam("provider") String provider
     ) {
         LoginResponse response = authService.socialLogin(accessToken, provider);
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", response.accessToken());
-        headers.set("RefreshToken", response.refreshToken());
+        
+        Cookie refreshTokenCookie = cookieUtil.createCookie(response.refreshToken());
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
-        return new ResponseEntity<>(MemberSignUpResponse.of(response), headers,
-                HttpStatus.OK);
+        return new ResponseEntity<>(MemberSignUpResponse.of(response), headers, HttpStatus.OK);
     }
 
-    @Operation(summary = "어드민 로그인", description = "아아디 패스워드 로그인 후 토큰 발급합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "로그인 성공",
-                    headers = {
-                            @Header(name = "Authorization", description = "Access Token", schema = @Schema(type = "string")),
-                            @Header(name = "RefreshToken", description = "Refresh Token", schema = @Schema(type = "string"))
-                    }
-            ),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "401", description = "인증 실패")
-    })
+    @Override
     @PostMapping("/admin/login")
-    public void adminLogin(
-            @RequestBody AdminLoginRequest request
-    ) {
+    public void adminLogin(@RequestBody AdminLoginRequest request) {
         // 실제 처리는 Security 필터에서 이루어지며, 이 메서드는 Swagger 명세용입니다.
     }
 }

--- a/src/main/java/com/server/ggini/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/server/ggini/domain/auth/controller/AuthController.java
@@ -1,25 +1,24 @@
 package com.server.ggini.domain.auth.controller;
 
 import com.server.ggini.domain.auth.dto.request.AdminLoginRequest;
+import com.server.ggini.domain.auth.dto.response.AccessTokenResponse;
 import com.server.ggini.domain.auth.dto.response.LoginResponse;
 import com.server.ggini.domain.auth.dto.response.MemberSignUpResponse;
+import com.server.ggini.domain.auth.dto.response.TokenResponse;
 import com.server.ggini.domain.auth.service.AuthService;
-import com.server.ggini.domain.member.domain.Member;
-import com.server.ggini.global.security.AuthConstants;
+import com.server.ggini.domain.auth.service.TokenReissueService;
+import com.server.ggini.global.error.exception.ErrorCode;
+import com.server.ggini.global.error.exception.NotFoundException;
 import com.server.ggini.global.security.utils.CookieUtil;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.headers.Header;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.Cookie;
-import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -32,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/auth")
 public class AuthController implements AuthControllerDocs {
 
+    private final TokenReissueService tokenReissueService;
     private final AuthService authService;
     private final CookieUtil cookieUtil;
 
@@ -55,5 +55,30 @@ public class AuthController implements AuthControllerDocs {
     @PostMapping("/admin/login")
     public void adminLogin(@RequestBody AdminLoginRequest request) {
         // 실제 처리는 Security 필터에서 이루어지며, 이 메서드는 Swagger 명세용입니다.
+    }
+
+    @Override
+    @GetMapping("/reissue")
+    public ResponseEntity<Void> reissueToken(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = validateRefreshTokenCookie(request);
+
+        TokenResponse tokenResponse = tokenReissueService.reissueToken(refreshToken);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", tokenResponse.accessToken());
+        response.addCookie(cookieUtil.createCookie(tokenResponse.refreshToken()));
+
+        return new ResponseEntity<>(null, headers, HttpStatus.OK);
+    }
+
+    private static String validateRefreshTokenCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            throw new NotFoundException(ErrorCode.BLANK_INPUT_VALUE);
+        }
+        Cookie[] cookies = request.getCookies();
+        return Arrays.stream(cookies)
+                .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(ErrorCode.BLANK_INPUT_VALUE));
     }
 }

--- a/src/main/java/com/server/ggini/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/server/ggini/domain/auth/controller/AuthControllerDocs.java
@@ -1,0 +1,98 @@
+package com.server.ggini.domain.auth.controller;
+
+import com.server.ggini.domain.auth.dto.response.MemberSignUpResponse;
+import com.server.ggini.domain.auth.dto.request.AdminLoginRequest;
+import com.server.ggini.global.error.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "인증", description = "소셜 로그인 인증 관련 API")
+public interface AuthControllerDocs {
+
+    @SecurityRequirements(value = {})
+    @Operation(
+        summary = "소셜 로그인",
+        description = "소셜 액세스 토큰으로 로그인하여 자체 액세스 토큰을 발급받고 리프레시 토큰을 쿠키에 설정합니다.",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "로그인 성공",
+                content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = MemberSignUpResponse.class)
+                ),
+                headers = {
+                    @Header(
+                        name = "Authorization",
+                        description = "발급된 액세스 토큰",
+                        schema = @Schema(type = "string")
+                    ),
+                    @Header(
+                        name = "Set-Cookie",
+                        description = "리프레시 토큰이 담긴 HTTP Only 쿠키",
+                        schema = @Schema(
+                            type = "string",
+                            example = "refreshToken=xxx; Path=/; HttpOnly; Secure; SameSite=None"
+                        )
+                    )
+                }
+            ),
+            @ApiResponse(
+                responseCode = "401",
+                description = "유효하지 않은 소셜 액세스 토큰",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+        }
+    )
+    ResponseEntity<MemberSignUpResponse> socialLogin(
+            @Parameter(description = "소셜 플랫폼 액세스 토큰", required = true) String accessToken,
+            @Parameter(description = "OAuth 제공자", example = "kakao", required = true) String provider
+    );
+
+    @SecurityRequirements(value = {})
+    @Operation(
+        summary = "어드민 로그인", 
+        description = "아이디 패스워드 로그인 후 토큰 발급합니다."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "로그인 성공",
+            headers = {
+                @Header(
+                    name = "Authorization", 
+                    description = "Access Token", 
+                    schema = @Schema(type = "string")
+                ),
+                @Header(
+                    name = "Set-Cookie",
+                    description = "리프레시 토큰이 담긴 HTTP Only 쿠키",
+                    schema = @Schema(
+                        type = "string",
+                        example = "refreshToken=xxx; Path=/; HttpOnly; Secure; SameSite=None"
+                    )
+                )
+            }
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+        )
+    })
+    void adminLogin(@RequestBody AdminLoginRequest request);
+} 

--- a/src/main/java/com/server/ggini/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/server/ggini/domain/auth/controller/AuthControllerDocs.java
@@ -4,95 +4,90 @@ import com.server.ggini.domain.auth.dto.response.MemberSignUpResponse;
 import com.server.ggini.domain.auth.dto.request.AdminLoginRequest;
 import com.server.ggini.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "인증", description = "소셜 로그인 인증 관련 API")
 public interface AuthControllerDocs {
 
     @SecurityRequirements(value = {})
     @Operation(
-        summary = "소셜 로그인",
-        description = "소셜 액세스 토큰으로 로그인하여 자체 액세스 토큰을 발급받고 리프레시 토큰을 쿠키에 설정합니다.",
-        responses = {
-            @ApiResponse(
-                responseCode = "200",
-                description = "로그인 성공",
-                content = @Content(
-                    mediaType = "application/json",
-                    schema = @Schema(implementation = MemberSignUpResponse.class)
-                ),
-                headers = {
-                    @Header(
-                        name = "Authorization",
-                        description = "발급된 액세스 토큰",
-                        schema = @Schema(type = "string")
+            summary = "소셜 로그인",
+            description = "소셜 액세스 토큰으로 로그인하여 자체 액세스 토큰을 발급받고 리프레시 토큰을 쿠키에 설정합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "로그인 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = MemberSignUpResponse.class)
+                            ),
+                            headers = {
+                                    @Header(
+                                            name = "Authorization",
+                                            description = "발급된 액세스 토큰",
+                                            schema = @Schema(type = "string")
+                                    ),
+                                    @Header(
+                                            name = "Set-Cookie",
+                                            description = "리프레시 토큰이 담긴 HTTP Only 쿠키",
+                                            schema = @Schema(
+                                                    type = "string",
+                                                    example = "refreshToken=xxx; Path=/; HttpOnly; Secure; SameSite=None"
+                                            )
+                                    )
+                            }
                     ),
-                    @Header(
-                        name = "Set-Cookie",
-                        description = "리프레시 토큰이 담긴 HTTP Only 쿠키",
-                        schema = @Schema(
-                            type = "string",
-                            example = "refreshToken=xxx; Path=/; HttpOnly; Secure; SameSite=None"
-                        )
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "유효하지 않은 소셜 액세스 토큰",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
                     )
-                }
-            ),
-            @ApiResponse(
-                responseCode = "401",
-                description = "유효하지 않은 소셜 액세스 토큰",
-                content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            )
-        }
+            }
     )
     ResponseEntity<MemberSignUpResponse> socialLogin(
-            @Parameter(description = "소셜 플랫폼 액세스 토큰", required = true) String accessToken,
-            @Parameter(description = "OAuth 제공자", example = "kakao", required = true) String provider
+            String accessToken,
+            String provider
     );
 
-    @SecurityRequirements(value = {})
     @Operation(
-        summary = "어드민 로그인", 
-        description = "아이디 패스워드 로그인 후 토큰 발급합니다."
-    )
-    @ApiResponses(value = {
-        @ApiResponse(
-            responseCode = "200",
-            description = "로그인 성공",
-            headers = {
-                @Header(
-                    name = "Authorization", 
-                    description = "Access Token", 
-                    schema = @Schema(type = "string")
-                ),
-                @Header(
-                    name = "Set-Cookie",
-                    description = "리프레시 토큰이 담긴 HTTP Only 쿠키",
-                    schema = @Schema(
-                        type = "string",
-                        example = "refreshToken=xxx; Path=/; HttpOnly; Secure; SameSite=None"
+            summary = "어드민 로그인",
+            description = "아이디 패스워드 로그인 후 토큰 발급합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "로그인 성공",
+                            headers = {
+                                    @Header(
+                                            name = "Authorization",
+                                            description = "Access Token",
+                                            schema = @Schema(type = "string")
+                                    ),
+                                    @Header(
+                                            name = "Set-Cookie",
+                                            description = "리프레시 토큰이 담긴 HTTP Only 쿠키",
+                                            schema = @Schema(
+                                                    type = "string",
+                                                    example = "refreshToken=xxx; Path=/; HttpOnly; Secure; SameSite=None"
+                                            )
+                                    )
+                            }
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "인증 실패",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
                     )
-                )
-            }
-        ),
-        @ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청",
-            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-        ),
-        @ApiResponse(
-            responseCode = "401",
-            description = "인증 실패",
-            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-        )
-    })
-    void adminLogin(@RequestBody AdminLoginRequest request);
+            })
+    void adminLogin(AdminLoginRequest request);
 } 

--- a/src/main/java/com/server/ggini/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/server/ggini/domain/auth/controller/AuthControllerDocs.java
@@ -1,5 +1,6 @@
 package com.server.ggini.domain.auth.controller;
 
+import com.server.ggini.domain.auth.dto.response.AccessTokenResponse;
 import com.server.ggini.domain.auth.dto.response.MemberSignUpResponse;
 import com.server.ggini.domain.auth.dto.request.AdminLoginRequest;
 import com.server.ggini.global.error.ErrorResponse;
@@ -10,6 +11,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "인증", description = "소셜 로그인 인증 관련 API")
@@ -90,4 +93,38 @@ public interface AuthControllerDocs {
                     )
             })
     void adminLogin(AdminLoginRequest request);
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = "리프레시 토큰을 통해 새로운 액세스 토큰을 발급하고 새로운 리프레시 토큰을 쿠키에 설정합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "토큰 재발급 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = AccessTokenResponse.class)
+                            ),
+                            headers = @Header(
+                                    name = "Set-Cookie",
+                                    description = "새로운 리프레시 토큰이 담긴 HTTP Only 쿠키",
+                                    schema = @Schema(
+                                            type = "string",
+                                            example = "refreshToken=xxx; Path=/; HttpOnly; Secure; SameSite=None"
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "유효하지 않은 리프레시 토큰",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "리프레시 토큰 쿠키 없음",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    )
+            }
+    )
+    ResponseEntity<Void> reissueToken(HttpServletRequest request, HttpServletResponse response);
 } 

--- a/src/main/java/com/server/ggini/domain/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,9 @@
+package com.server.ggini.domain.auth.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AccessTokenResponse(
+        @NotNull(message = "accessToken을 입력해주세요.")
+        String accessToken
+) {
+}

--- a/src/main/java/com/server/ggini/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/server/ggini/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.server.ggini.domain.auth.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/server/ggini/domain/auth/service/TokenReissueService.java
+++ b/src/main/java/com/server/ggini/domain/auth/service/TokenReissueService.java
@@ -1,0 +1,65 @@
+package com.server.ggini.domain.auth.service;
+
+import com.server.ggini.domain.auth.dto.response.TokenResponse;
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.domain.member.service.MemberService;
+import com.server.ggini.global.error.exception.ErrorCode;
+import com.server.ggini.global.error.exception.InvalidValueException;
+import com.server.ggini.global.security.exception.JwtInvalidException;
+import com.server.ggini.global.security.utils.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenReissueService {
+
+    private final JwtUtil jwtUtil;
+    private final MemberService memberService;
+
+    @Transactional
+    public TokenResponse reissueToken(String refreshToken) {
+        if (refreshToken == null) {
+            throw new InvalidValueException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        Claims claims = getClaims(refreshToken);
+        final Member member = getMemberById(claims.getSubject());
+
+        // 새로운 액세스 토큰과 리프레시 토큰 생성
+        String newAccessToken = jwtUtil.generateAccessToken(member);
+        String newRefreshToken = jwtUtil.generateRefreshToken(member);
+
+        return new TokenResponse(newAccessToken, newRefreshToken);
+    }
+
+    private Claims getClaims(String refreshToken) {
+        Claims claims;
+        try {
+            claims = jwtUtil.getRefreshTokenClaims(refreshToken);
+        } catch (ExpiredJwtException expiredJwtException) {
+            throw new JwtInvalidException(ErrorCode.EXPIRED_TOKEN.getMessage());
+        } catch (SignatureException signatureException) {
+            throw new JwtInvalidException(ErrorCode.WRONG_TYPE_TOKEN.getMessage());
+        } catch (MalformedJwtException malformedJwtException) {
+            throw new JwtInvalidException(ErrorCode.UNSUPPORTED_TOKEN.getMessage());
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw new JwtInvalidException(ErrorCode.UNKNOWN_ERROR.getMessage());
+        }
+        return claims;
+    }
+
+    private Member getMemberById(String id) {
+        try {
+            return memberService.getMemberById(Long.parseLong(id));
+        } catch (Exception e) {
+            throw new BadCredentialsException(ErrorCode.BAD_CREDENTIALS.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/server/ggini/domain/member/controller/MemberController.java
+++ b/src/main/java/com/server/ggini/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.server.ggini.domain.member.dto.response.MemberGetResponse;
 import com.server.ggini.global.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "회원", description = "회원 관련 API")
 @RestController
 @RequestMapping("/api/v1/member")
 @RequiredArgsConstructor

--- a/src/main/java/com/server/ggini/domain/member/controller/MemberLocalAuthController.java
+++ b/src/main/java/com/server/ggini/domain/member/controller/MemberLocalAuthController.java
@@ -5,6 +5,7 @@ import com.server.ggini.domain.member.dto.request.LocalAuthRequest;
 import com.server.ggini.domain.member.dto.response.LocalAuthResponse;
 import com.server.ggini.global.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "회원", description = "회원 관련 API")
 @RestController
 @RequestMapping("/api/v1/localAuth")
 @RequiredArgsConstructor

--- a/src/main/java/com/server/ggini/domain/restaurant/controller/NeedsTagsController.java
+++ b/src/main/java/com/server/ggini/domain/restaurant/controller/NeedsTagsController.java
@@ -3,6 +3,7 @@ package com.server.ggini.domain.restaurant.controller;
 import com.server.ggini.domain.restaurant.dto.response.NeedsTagGetResponse;
 import com.server.ggini.domain.restaurant.repository.NeedsTagRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "식당", description = "식당 관련 API")
 @RestController
 @RequestMapping("/api/v1/needsTags")
 @RequiredArgsConstructor

--- a/src/main/java/com/server/ggini/domain/restaurant/controller/PriceTagsController.java
+++ b/src/main/java/com/server/ggini/domain/restaurant/controller/PriceTagsController.java
@@ -3,6 +3,7 @@ package com.server.ggini.domain.restaurant.controller;
 import com.server.ggini.domain.restaurant.dto.response.PriceTagGetResponse;
 import com.server.ggini.domain.restaurant.repository.PriceTagsRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "식당", description = "식당 관련 API")
 @RestController
 @RequestMapping("/api/v1/priceTags")
 @RequiredArgsConstructor

--- a/src/main/java/com/server/ggini/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/server/ggini/domain/restaurant/controller/RestaurantController.java
@@ -6,6 +6,7 @@ import com.server.ggini.domain.restaurant.repository.RestaurantRepository;
 import com.server.ggini.domain.restaurant.service.RestaurantGetService;
 import com.server.ggini.global.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "식당", description = "식당 관련 API")
 @RestController
 @RequestMapping("/api/v1/restaurants")
 @RequiredArgsConstructor

--- a/src/main/java/com/server/ggini/domain/restaurant/controller/RestaurantSearchController.java
+++ b/src/main/java/com/server/ggini/domain/restaurant/controller/RestaurantSearchController.java
@@ -1,6 +1,7 @@
 package com.server.ggini.domain.restaurant.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "식당", description = "식당 관련 API")
 @RestController
 @RequestMapping("/api/v1/restaurants")
 @RequiredArgsConstructor

--- a/src/main/java/com/server/ggini/domain/restaurant/controller/SeoulRestaurantSearchController.java
+++ b/src/main/java/com/server/ggini/domain/restaurant/controller/SeoulRestaurantSearchController.java
@@ -1,6 +1,7 @@
 package com.server.ggini.domain.restaurant.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "식당", description = "식당 관련 API")
 @RestController
 @RequestMapping("/api/v1/seoulRestaurants")
 @RequiredArgsConstructor

--- a/src/main/java/com/server/ggini/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/server/ggini/domain/review/controller/ReviewController.java
@@ -7,6 +7,7 @@ import com.server.ggini.domain.review.service.ReviewCreateService;
 import com.server.ggini.domain.review.service.ReviewFirstCreateService;
 import com.server.ggini.global.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "리뷰", description = "리뷰 관련 API")
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor

--- a/src/main/java/com/server/ggini/domain/review/controller/ReviewImageUploadController.java
+++ b/src/main/java/com/server/ggini/domain/review/controller/ReviewImageUploadController.java
@@ -1,0 +1,38 @@
+package com.server.ggini.domain.review.controller;
+
+import com.server.ggini.domain.review.dto.response.PresignedUrlResponse;
+import com.server.ggini.domain.review.service.ReviewImageUploadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "리뷰", description = "리뷰 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/images")
+public class ReviewImageUploadController {
+
+    private final ReviewImageUploadService reviewImageUploadService;
+
+    @Operation(summary = "이미지 업로드를 위한 presigned URL 발급", description = "url의 ? 쿼리 파라미터전까지가 이미지의 static url입니다.")
+    @GetMapping("/problem/{restaurantId}/presigned-url")
+    public ResponseEntity<PresignedUrlResponse> getProblemImagePresignedUrl(
+            @PathVariable("restaurantId") Long restaurantId
+    ) {
+        String presignedUrl = reviewImageUploadService.generateReviewImagePresignedUrl(restaurantId);
+        return ResponseEntity.ok(PresignedUrlResponse.of(presignedUrl));
+    }
+
+    @Operation(summary = "이미지 업로드 완료 후 URL 조회")
+    @GetMapping("/{fileName}")
+    public ResponseEntity<String> getImageUrl(
+            @PathVariable("fileName") String fileName) {
+        String imageUrl = reviewImageUploadService.getImageUrl(fileName);
+        return ResponseEntity.ok(imageUrl);
+    }
+}

--- a/src/main/java/com/server/ggini/domain/review/controller/ReviewImageUploadController.java
+++ b/src/main/java/com/server/ggini/domain/review/controller/ReviewImageUploadController.java
@@ -20,8 +20,8 @@ public class ReviewImageUploadController {
     private final ReviewImageUploadService reviewImageUploadService;
 
     @Operation(summary = "이미지 업로드를 위한 presigned URL 발급", description = "url의 ? 쿼리 파라미터전까지가 이미지의 static url입니다.")
-    @GetMapping("/problem/{restaurantId}/presigned-url")
-    public ResponseEntity<PresignedUrlResponse> getProblemImagePresignedUrl(
+    @GetMapping("/review/{restaurantId}/presigned-url")
+    public ResponseEntity<PresignedUrlResponse> getReviewImagePresignedUrl(
             @PathVariable("restaurantId") Long restaurantId
     ) {
         String presignedUrl = reviewImageUploadService.generateReviewImagePresignedUrl(restaurantId);

--- a/src/main/java/com/server/ggini/domain/review/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/server/ggini/domain/review/dto/response/PresignedUrlResponse.java
@@ -1,0 +1,14 @@
+package com.server.ggini.domain.review.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PresignedUrlResponse(
+        @NotNull(message = "사전 서명된 URL은 필수입니다")
+        String presignedUrl
+) {
+    public static PresignedUrlResponse of(String presignedUrl) {
+        return new PresignedUrlResponse(
+                presignedUrl
+        );
+    }
+}

--- a/src/main/java/com/server/ggini/domain/review/service/ReviewImageUploadService.java
+++ b/src/main/java/com/server/ggini/domain/review/service/ReviewImageUploadService.java
@@ -1,0 +1,38 @@
+package com.server.ggini.domain.review.service;
+
+import com.amazonaws.HttpMethod;
+import com.server.ggini.domain.member.domain.Member;
+import com.server.ggini.domain.restaurant.domain.Restaurant;
+import com.server.ggini.domain.restaurant.repository.RestaurantRepository;
+import com.server.ggini.global.util.s3.S3Util;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewImageUploadService {
+
+    private static final String RESTAURANT_IMAGE_PREFIX = "restaurant/";
+    private final S3Util s3Util;
+    private final RestaurantRepository restaurantRepository;
+
+    public String generateReviewImagePresignedUrl(Long restaurantId) {
+        Restaurant restaurant = restaurantRepository.findByIdElseThrow(restaurantId);
+        String fileName = generateReviewImageFileName(restaurant);
+        return s3Util.getS3PresignedUrl(fileName, HttpMethod.PUT);
+    }
+
+    private String generateReviewImageFileName(Restaurant restaurant) {
+        String uuid = UUID.randomUUID().toString();
+        return String.format("%s/%s/%s.jpg",
+                RESTAURANT_IMAGE_PREFIX,
+                restaurant.getId() + " - " +restaurant.getName(),
+                uuid
+        );
+    }
+
+    public String getImageUrl(String fileName) {
+        return s3Util.getS3ObjectUrl(fileName);
+    }
+} 

--- a/src/main/java/com/server/ggini/global/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/server/ggini/global/config/properties/PropertiesConfig.java
@@ -1,11 +1,13 @@
 package com.server.ggini.global.config.properties;
 
 import com.server.ggini.global.properties.jwt.JwtProperties;
+import com.server.ggini.global.properties.swagger.SwaggerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @EnableConfigurationProperties({
-    JwtProperties.class
+    JwtProperties.class,
+    SwaggerProperties.class
 })
 @Configuration
 public class PropertiesConfig {

--- a/src/main/java/com/server/ggini/global/config/s3/AwsS3Config.java
+++ b/src/main/java/com/server/ggini/global/config/s3/AwsS3Config.java
@@ -1,0 +1,36 @@
+package com.server.ggini.global.config.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials =
+            new BasicAWSCredentials(
+                accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .build();
+
+    }
+}

--- a/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
 
     private String[] allowUrls = {"/", "/favicon.ico",
-        "/api/v1/auth/oauth/**", "/swagger-ui/**", "/v3/**"};
+        "/api/v1/auth/**", "/swagger-ui/**", "/v3/**"};
 
     @Value("${cors-allowed-origins}")
     private List<String> corsAllowedOrigins;

--- a/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/ggini/global/config/security/SecurityConfig.java
@@ -38,8 +38,8 @@ public class SecurityConfig {
     private final EmailPasswordSuccessHandler emailPasswordSuccessHandler;
     private final JwtUtil jwtUtil;
 
-    private String[] allowUrls = {"/", "/favicon.ico",
-        "/api/v1/auth/**", "/swagger-ui/**", "/v3/**"};
+    private final String[] allowUrls = {"/", "/favicon.ico",
+        "/api/v1/auth/oauth/**", "/swagger-ui/**", "/v3/**"};
 
     @Value("${cors-allowed-origins}")
     private List<String> corsAllowedOrigins;

--- a/src/main/java/com/server/ggini/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/server/ggini/global/config/swagger/SwaggerConfig.java
@@ -1,20 +1,36 @@
 package com.server.ggini.global.config.swagger;
 
+import com.server.ggini.global.properties.swagger.SwaggerProperties;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
+
+    private final SwaggerProperties swaggerProperties;
 
     private SecurityScheme createAPIKeyScheme() {
         return new SecurityScheme().type(SecurityScheme.Type.HTTP)
                 .bearerFormat("JWT")
                 .scheme("Bearer");
+    }
+
+    private List<Server> addServerUrl() {
+        return swaggerProperties.servers().stream()
+                .map(serverProp -> new Server()
+                        .url(serverProp.url())
+                        .description(serverProp.description()))
+                .collect(Collectors.toList());
     }
 
     @Bean
@@ -23,6 +39,7 @@ public class SwaggerConfig {
                 .components(new Components().addSecuritySchemes("JWT", createAPIKeyScheme()))
                 .info(new Info().title("끼니 API 명세서")
                         .description("끼니 API 명세서 입니다")
-                        .version("v0.0.1"));
+                        .version("v0.0.1"))
+                .servers(addServerUrl());
     }
 }

--- a/src/main/java/com/server/ggini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/server/ggini/global/error/exception/ErrorCode.java
@@ -43,6 +43,9 @@ public enum ErrorCode {
 
     //Review
     REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 리뷰를 작성하셨습니다."),
+
+    //Image
+    IMAGE_FILE_NOT_FOUND_IN_S3(HttpStatus.NOT_FOUND, "S3에 해당 이미지 파일을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/server/ggini/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/server/ggini/global/error/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 엔티티를 찾을 수 없습니다."),
     BAD_CREDENTIALS(HttpStatus.UNAUTHORIZED, "잘못된 인증 정보입니다"),
     INVALID_LENGTH_VALUE(HttpStatus.BAD_REQUEST, "입력 값의 길이가 잘못되었습니다."),
+    BLANK_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력 값이 비어있습니다."),
 
     //Auth
     AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "시큐리티 인증 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/server/ggini/global/properties/swagger/SwaggerProperties.java
+++ b/src/main/java/com/server/ggini/global/properties/swagger/SwaggerProperties.java
@@ -1,0 +1,15 @@
+package com.server.ggini.global.properties.swagger;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "swagger")
+public record SwaggerProperties(
+        List<ServerProperties> servers
+) {
+    public static record ServerProperties(
+            String url,
+            String description
+    ) {
+    }
+}

--- a/src/main/java/com/server/ggini/global/security/handler/EmailPasswordSuccessHandler.java
+++ b/src/main/java/com/server/ggini/global/security/handler/EmailPasswordSuccessHandler.java
@@ -27,7 +27,6 @@ public class EmailPasswordSuccessHandler extends SavedRequestAwareAuthentication
         String accessToken = jwtUtil.generateAccessToken(member);
         String refreshToken = jwtUtil.generateRefreshToken(member);
         response.addHeader(AuthConstants.AUTH_HEADER, AuthConstants.TOKEN_TYPE + " " + accessToken);
-
         response.addCookie(cookieUtil.createCookie(refreshToken));
     }
 

--- a/src/main/java/com/server/ggini/global/security/handler/EmailPasswordSuccessHandler.java
+++ b/src/main/java/com/server/ggini/global/security/handler/EmailPasswordSuccessHandler.java
@@ -2,9 +2,12 @@ package com.server.ggini.global.security.handler;
 
 import com.server.ggini.domain.member.domain.Member;
 import com.server.ggini.global.security.AuthConstants;
+import com.server.ggini.global.security.utils.CookieUtil;
 import com.server.ggini.global.security.utils.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
@@ -14,6 +17,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class EmailPasswordSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 
+    private final CookieUtil cookieUtil;
     private final JwtUtil jwtUtil;
 
     @Override
@@ -23,7 +27,8 @@ public class EmailPasswordSuccessHandler extends SavedRequestAwareAuthentication
         String accessToken = jwtUtil.generateAccessToken(member);
         String refreshToken = jwtUtil.generateRefreshToken(member);
         response.addHeader(AuthConstants.AUTH_HEADER, AuthConstants.TOKEN_TYPE + " " + accessToken);
-        response.addHeader(AuthConstants.REFRESH_TOKEN_HEADER, AuthConstants.TOKEN_TYPE + " " + refreshToken);
+
+        response.addCookie(cookieUtil.createCookie(refreshToken));
     }
 
 }

--- a/src/main/java/com/server/ggini/global/security/utils/CookieUtil.java
+++ b/src/main/java/com/server/ggini/global/security/utils/CookieUtil.java
@@ -1,0 +1,20 @@
+package com.server.ggini.global.security.utils;
+
+import jakarta.servlet.http.Cookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public Cookie createCookie(String refreshToken) {
+        String cookieName = "refreshToken";
+        Cookie cookie = new Cookie(cookieName, refreshToken);
+
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 60 * 24 * 7); //일주일
+        cookie.setAttribute("SameSite", "None");
+        return cookie;
+    }
+}

--- a/src/main/java/com/server/ggini/global/security/utils/JwtUtil.java
+++ b/src/main/java/com/server/ggini/global/security/utils/JwtUtil.java
@@ -58,6 +58,15 @@ public class JwtUtil {
                 .getBody();
     }
 
+    public Claims getRefreshTokenClaims(String refreshToken) {
+        return Jwts.parserBuilder()
+                .requireIssuer(jwtProperties.issuer())
+                .setSigningKey(getRefreshTokenKey())
+                .build()
+                .parseClaimsJws(refreshToken)
+                .getBody();
+    }
+
     private Key getAccessTokenKey() {
         return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
     }

--- a/src/main/java/com/server/ggini/global/util/s3/S3Util.java
+++ b/src/main/java/com/server/ggini/global/util/s3/S3Util.java
@@ -1,0 +1,55 @@
+package com.server.ggini.global.util.s3;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.server.ggini.global.error.exception.ErrorCode;
+import com.server.ggini.global.error.exception.NotFoundException;
+import java.io.File;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class S3Util {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public void putObject(File file, String fileName) {
+        amazonS3.putObject(new PutObjectRequest(bucketName, fileName, file));
+    }
+
+    public String getS3ObjectUrl(String fileName) {
+        if (!amazonS3.doesObjectExist(bucketName, fileName)) {
+            throw new NotFoundException(ErrorCode.IMAGE_FILE_NOT_FOUND_IN_S3);
+        }
+        return amazonS3.getUrl(bucketName, fileName).toString();
+    }
+
+    public String getS3PresignedUrl(String fileName, HttpMethod httpMethod) {
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucketName, fileName)
+                        .withMethod(httpMethod)
+                        .withExpiration(getPreSignedUrlExpiration());
+
+        return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+    }
+
+    private Date getPreSignedUrlExpiration() {
+        final int PRESIGNED_EXPIRATION = 1000 * 60 * 30; //30분
+
+        Date expiration = new Date();
+        var expTimeMillis = expiration.getTime();
+        expTimeMillis += PRESIGNED_EXPIRATION;
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+
+}

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -1,0 +1,13 @@
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET}
+      signature-version: AWS4-HMAC-SHA256
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+      auto: false
+    stack:
+      auto: false

--- a/src/main/resources/application-aws.yml
+++ b/src/main/resources/application-aws.yml
@@ -11,3 +11,10 @@ cloud:
       auto: false
     stack:
       auto: false
+
+swagger:
+  servers:
+    - url: http://13.209.129.138:8080
+      description: "kkini dev http 서버입니다."
+    - url: http://localhost:8080
+      description: "kkini local 서버입니다."

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,5 +23,10 @@ management:
     health:
       enabled: true
 
-
+swagger:
+  servers:
+    - url: http://13.209.129.138:8080
+      description: "kkini dev http 서버입니다."
+    - url: http://localhost:8080
+      description: "kkini local 서버입니다."
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,4 +22,9 @@ spring:
     hibernate:
       ddl-auto: update
 
-
+swagger:
+  servers:
+    - url: http://13.209.129.138:8080
+      description: "kkini dev http 서버입니다."
+    - url: http://localhost:8080
+      description: "kkini local 서버입니다."

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
       prod: "prod, datasource"
     include:
       - security
+      - aws
 
 logging:
   level:

--- a/src/test/java/com/server/ggini/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/server/ggini/domain/auth/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.server.ggini.domain.auth.controller;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -58,7 +59,11 @@ class AuthControllerTest {
                             .content(requestBody))
                     .andExpect(status().isOk()) // 200 응답 확인
                     .andExpect(header().exists("Authorization"))
-                    .andExpect(header().exists("RefreshToken"));
+                    .andExpect(cookie().exists("refreshToken")) // 리프레시 토큰 쿠키 존재 확인
+                    .andExpect(cookie().httpOnly("refreshToken", true)) // HTTP Only 설정 확인
+                    .andExpect(cookie().secure("refreshToken", true)) // Secure 설정 확인
+                    .andExpect(cookie().path("refreshToken", "/")) // 쿠키 경로 확인
+                    .andExpect(cookie().attribute("refreshToken", "SameSite", "None"));
 
         }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -23,3 +23,17 @@ kakao:
 cors-allowed-origins:
   http://localhost:8080,
   http://localhost:3000,
+
+cloud:
+  aws:
+    s3:
+      bucket: test
+      signature-version: AWS4-HMAC-SHA256
+    credentials:
+      access-key: test
+      secret-key: test
+    region:
+      static: test
+      auto: false
+    stack:
+      auto: false


### PR DESCRIPTION
## 🌱 관련 이슈
- close #22

## 📌 작업 내용 및 특이사항
1.  jwt refresh 토큰으로 accessToken을 재발급 하는 reissue api를 추가하였습니다.
- 로그인이나 토큰 재발급 시 jwt refreshToken이 cookie에 담아서 전송됩니다.
     - http-only, samesite, secure 설정이 되어 있습니다.
     - http-only : XSS 공격 방지
     - samesite, secure : CSRF 공격 방지

2. swagger ui를 같은 도메인 끼리 묶어 깔끔하게 수정하였습니다.
![image](https://github.com/user-attachments/assets/99e28e26-4521-4f3c-8f41-aef46277a032)

3. 리뷰 이미지 등록을 위한 프린사인 Url 발급 로직을 추가했습니다.

## 📝 참고사항
- 

## 📚 기타
- 
